### PR TITLE
TFP-3834 Rettet slik at riktig månedsbeløp vises når KUN_YTELSE og 80…

### DIFF
--- a/content/templates/innvilget-foreldrepenger/beregning_nb.hbs
+++ b/content/templates/innvilget-foreldrepenger/beregning_nb.hbs
@@ -3,17 +3,17 @@
 **Inntekt vi har brukt i beregningen**
 
 {{#eq harBruktBruttoBeregningsgrunnlag true}}
-Vi har brukt {{bruttoBeregningsgrunnlag}} kroner i året før skatt i beregningen av foreldrepengene dine.
+Vi har brukt {{formaterKroner bruttoBeregningsgrunnlag}} kroner i året før skatt i beregningen av foreldrepengene dine.
 {{/eq}}
 {{~#each beregningsgrunnlagregler}}
 {{~#if (or (eq regelStatus "ARBEIDSTAKER") (eq regelStatus "KOMBINERT_AT_FL_SN") (eq regelStatus "KOMBINERT_AT_FL") (eq regelStatus "KOMBINERT_AT_SN"))}}
 {{~#each andelListe}}
 {{~#if (and (eq this.aktivitetStatus "ARBEIDSTAKER" ) (neq this.etterlønnSluttpakke))}}
 {{#eq @../antallArbeidsgivereIBeregningUtenEtterlønnSluttpakke 1}}
-Inntekten din hos {{this.arbeidsgiverNavn}} er {{this.månedsinntekt}} kroner i måneden. Arbeidsgiveren din har gitt oss disse opplysningene.
+Inntekten din hos {{this.arbeidsgiverNavn}} er {{formaterKroner this.månedsinntekt}} kroner i måneden. Arbeidsgiveren din har gitt oss disse opplysningene.
 {{/eq}}
 {{#gt @../antallArbeidsgivereIBeregningUtenEtterlønnSluttpakke 1}}
-Inntekten din hos {{this.arbeidsgiverNavn}} er {{this.månedsinntekt}} kroner i måneden.
+Inntekten din hos {{this.arbeidsgiverNavn}} er {{formaterKroner this.månedsinntekt}} kroner i måneden.
 {{/gt}}
 {{/if}}
 {{/each}}
@@ -23,7 +23,7 @@ Arbeidsgiverne dine har gitt oss disse opplysningene.
 {{/if}}
 {{~#each andelListe}}
 {{#eq this.etterlønnSluttpakke true }}
-Vi har brukt {{this.månedsinntekt}} kroner i måneden før skatt i beregningen av foreldrepengene dine. Dette er lønnen du har hatt fra den tidligere arbeidsgiveren din etter at arbeidsforholdet ble avsluttet.
+Vi har brukt {{formaterKroner this.månedsinntekt}} kroner i måneden før skatt i beregningen av foreldrepengene dine. Dette er lønnen du har hatt fra den tidligere arbeidsgiveren din etter at arbeidsforholdet ble avsluttet.
 {{/eq}}
 {{/each}}
 
@@ -34,7 +34,7 @@ Dette er gjennomsnittet av inntekten din fra de siste tre månedene. Hvis du net
 {{~#if (or (eq regelStatus "FRILANSER") (eq regelStatus "KOMBINERT_AT_FL_SN") (eq regelStatus "KOMBINERT_AT_FL") (eq regelStatus "KOMBINERT_FL_SN"))}}
 {{~#each andelListe}}
 {{#eq this.aktivitetStatus "FRILANSER"}}
-Inntekten din som frilanser er {{this.månedsinntekt}} kroner i måneden.  Oppdragsgiveren eller oppdragsgiverne dine har gitt oss disse opplysningene.
+Inntekten din som frilanser er {{formaterKroner this.månedsinntekt}} kroner i måneden.  Oppdragsgiveren eller oppdragsgiverne dine har gitt oss disse opplysningene.
 {{~#if (neq this.aktivitetStatus "KOMBINERT_AT_FL")}}
 Dette er gjennomsnittet av inntekten din fra de siste tre månedene. Hvis du nettopp har begynt å arbeide som frilanser, har vi brukt inntektene etter at du startet.
 {{else}}
@@ -48,19 +48,19 @@ Dette er gjennomsnittet av inntekten du har hatt som arbeidstaker og frilanser d
 {{~#each andelListe}}
 {{#eq @../regelStatus "SELVSTENDIG_NÆRINGSDRIVENDE"}}
 {{#eq @../snNyoppstartet false}}
-Vi har beregnet foreldrepengene dine ut fra en årsinntekt på {{this.årsinntekt}} kroner. Dette er gjennomsnittet av inntekten du hadde i {{sistLignedeÅr}}, {{add sistLignedeÅr -1}} og {{add sistLignedeÅr -2}}.
+Vi har beregnet foreldrepengene dine ut fra en årsinntekt på {{formaterKroner this.årsinntekt}} kroner. Dette er gjennomsnittet av inntekten du hadde i {{sistLignedeÅr}}, {{add sistLignedeÅr -1}} og {{add sistLignedeÅr -2}}.
 {{else}}
-Vi har fastsatt foreldrepengene dine til {{this.årsinntekt}} kroner i året. Fordi du har begynt å jobbe i løpet av de tre siste årene, har vi beregnet inntekten din ut fra de opplysningene vi har for det siste året.
+Vi har fastsatt foreldrepengene dine til {{formaterKroner this.årsinntekt}} kroner i året. Fordi du har begynt å jobbe i løpet av de tre siste årene, har vi beregnet inntekten din ut fra de opplysningene vi har for det siste året.
 {{/eq}}
 
 {{~#if (eq @../regelStatus "KOMBINERT_AT_SN")}}
-Næringsinntekten din er fastsatt til {{this.årsinntekt}} kroner i året. Når vi beregner foreldrepenger ut fra næringsinntekten din, bruker vi gjennomsnittet av de siste tre årene vi har fått oppgitt av Skatteetaten. Hvis du nettopp har begynt å arbeide, bruker vi inntekten vi har fått opplyst for det siste året. Dette gjennomsnittet kan også inneholde arbeidsinntekten din. De er trukket fra i beregningen av næringsinntekten.
+Næringsinntekten din er fastsatt til {{formaterKroner this.årsinntekt}} kroner i året. Når vi beregner foreldrepenger ut fra næringsinntekten din, bruker vi gjennomsnittet av de siste tre årene vi har fått oppgitt av Skatteetaten. Hvis du nettopp har begynt å arbeide, bruker vi inntekten vi har fått opplyst for det siste året. Dette gjennomsnittet kan også inneholde arbeidsinntekten din. De er trukket fra i beregningen av næringsinntekten.
 {{/if}}
 {{~#if (eq @../regelStatus "KOMBINERT_FL_SN")}}
-Næringsinntekten din er fastsatt til {{this.årsinntekt}} kroner i året. Når vi beregner foreldrepenger ut fra næringsinntekten din, bruker vi gjennomsnittet av de siste tre årene vi har fått oppgitt av Skatteetaten. Hvis du nettopp har begynt å arbeide, bruker vi inntekten vi har fått opplyst for det siste året. Dette gjennomsnittet kan også inneholde inntekten din som frilanser. Den er trukket fra i beregningen av næringsinntekten.
+Næringsinntekten din er fastsatt til {{formaterKroner this.årsinntekt}} kroner i året. Når vi beregner foreldrepenger ut fra næringsinntekten din, bruker vi gjennomsnittet av de siste tre årene vi har fått oppgitt av Skatteetaten. Hvis du nettopp har begynt å arbeide, bruker vi inntekten vi har fått opplyst for det siste året. Dette gjennomsnittet kan også inneholde inntekten din som frilanser. Den er trukket fra i beregningen av næringsinntekten.
 {{/if}}
 {{~#if (eq @../regelStatus "KOMBINERT_AT_FL_SN")}}
-Næringsinntekten din er fastsatt til {{this.årsinntekt}} kroner i året. Når vi beregner foreldrepenger ut fra næringsinntekten din, bruker vi gjennomsnittet av de siste tre årene vi har fått oppgitt av Skatteetaten. Hvis du nettopp har begynt å arbeide, bruker vi inntekten vi har fått opplyst for det siste året. Dette gjennomsnittet kan også inneholde arbeidsinntekten din og inntekten din som frilanser. De er trukket fra i beregningen av næringsinntekten.
+Næringsinntekten din er fastsatt til {{formaterKroner this.årsinntekt}} kroner i året. Når vi beregner foreldrepenger ut fra næringsinntekten din, bruker vi gjennomsnittet av de siste tre årene vi har fått oppgitt av Skatteetaten. Hvis du nettopp har begynt å arbeide, bruker vi inntekten vi har fått opplyst for det siste året. Dette gjennomsnittet kan også inneholde arbeidsinntekten din og inntekten din som frilanser. De er trukket fra i beregningen av næringsinntekten.
 {{/if}}
 {{/eq}}
 {{/each}}
@@ -81,10 +81,10 @@ Arbeidsinntekten og inntekten din som frilanser er høyere enn gjennomsnittet av
 {{~#each perioder}}
 {{~#each arbeidsforholdsliste}}
 {{~#eq this.naturalytelseEndringType "STOPP"}}
-Fra og med {{this.naturalytelseEndringDato}} får du {{this.naturalytelseNyDagsats}} kroner per dag før skatt fordi du mister naturalytelsen din fra {{this.arbeidsgiverNavn}}.
+Fra og med {{this.naturalytelseEndringDato}} får du {{formaterKroner this.naturalytelseNyDagsats}} kroner per dag før skatt fordi du mister naturalytelsen din fra {{this.arbeidsgiverNavn}}.
 {{/eq}}
 {{~#eq this.naturalytelseEndringType "START"}}
-Fra og med {{this.naturalytelseEndringDato}} får du {{this.naturalytelseNyDagsats}} kroner per dag før skatt fordi du får naturalytelsen din fra {{this.arbeidsgiverNavn}}.
+Fra og med {{this.naturalytelseEndringDato}} får du {{formaterKroner this.naturalytelseNyDagsats}} kroner per dag før skatt fordi du får naturalytelsen din fra {{this.arbeidsgiverNavn}}.
 {{/eq}}
 {{/each}}
 {{/each}}
@@ -92,15 +92,15 @@ Fra og med {{this.naturalytelseEndringDato}} får du {{this.naturalytelseNyDagsa
 Vi har fastsatt foreldrepengene dine til {{dagsats}} kroner per dag før skatt. Du har både jobbet og mottatt dagpenger. Vi har beregnet foreldrepengene dine ut fra de seks beste av de siste ti månedene.
 {{/eq}}
 {{~#if (and (eq regelStatus "DAGPENGER") (eq erBesteberegning false))}}
-Du fikk {{dagsats}} kroner per dag før skatt i dagpenger. Vi har brukt dette beløpet i beregningen av foreldrepengene dine.
+Du fikk {{formaterKroner dagsats}} kroner per dag før skatt i dagpenger. Vi har brukt dette beløpet i beregningen av foreldrepengene dine.
 {{/if}}
 {{~#eq regelStatus "MILITÆR_ELLER_SIVIL"}}
 Vi har fastsatt foreldrepengene dine til tre ganger grunnbeløpet fordi du har vært i militæret, i siviltjeneste eller sivilforsvaret.
 {{/eq}}
 {{~#eq regelStatus "KUN_YTELSE"}}
-Vi har beregnet foreldrepengene dine ut fra en inntekt på {{månedsbeløp}} kroner i måneden før skatt. Dette er gjennomsnittet av inntekten du har fått fra NAV for de siste tre månedene.
+Vi har beregnet foreldrepengene dine ut fra en inntekt på {{formaterKroner (divide 12 bruttoBeregningsgrunnlag)}} kroner i måneden før skatt. Dette er gjennomsnittet av inntekten du har fått fra NAV de siste tre månedene.
 {{/eq}}
 {{~#eq regelStatus "ARBEIDSAVKLARINGSPENGER"}}
-Du fikk {{dagsats}} kroner per dag før skatt i arbeidsavklaringspenger. Vi har brukt dette beløpet i beregningen av foreldrepengene dine.
+Du fikk {{formaterKroner dagsats}} kroner per dag før skatt i arbeidsavklaringspenger. Vi har brukt dette beløpet i beregningen av foreldrepengene dine.
 {{/eq}}
 {{/each}}

--- a/content/templates/innvilget-foreldrepenger/innvilget/uttak_fullt_nb.hbs
+++ b/content/templates/innvilget-foreldrepenger/innvilget/uttak_fullt_nb.hbs
@@ -1,1 +1,1 @@
-* Du tar ut foreldrepenger fra og med {{this.periodeFom}} til og med {{this.periodeTom}}. I denne perioden får du {{this.periodeDagsats}} kroner per dag før skatt.
+* Du tar ut foreldrepenger fra og med {{this.periodeFom}} til og med {{this.periodeTom}}. I denne perioden får du {{formaterKroner this.periodeDagsats}} kroner per dag før skatt.

--- a/content/templates/innvilget-foreldrepenger/innvilget/uttak_prosent_nb.hbs
+++ b/content/templates/innvilget-foreldrepenger/innvilget/uttak_prosent_nb.hbs
@@ -1,1 +1,1 @@
-* Du tar ut {{this.prioritertUtbetalingsgrad}} prosent foreldrepenger fra og med {{this.periodeFom}} til og med {{this.periodeTom}}. I denne perioden får du {{this.periodeDagsats}} kroner per dag før skatt.
+* Du tar ut {{this.prioritertUtbetalingsgrad}} prosent foreldrepenger fra og med {{this.periodeFom}} til og med {{this.periodeTom}}. I denne perioden får du {{formaterKroner this.periodeDagsats}} kroner per dag før skatt.

--- a/content/templates/innvilget-foreldrepenger/innvilget_nb.hbs
+++ b/content/templates/innvilget-foreldrepenger/innvilget_nb.hbs
@@ -32,7 +32,7 @@ Vi har redusert utbetalingen din fordi du jobber i denne perioden. Selv om du jo
 
 
 {{#eq årsak "2038"}}{{#neq this.prioritertUtbetalingsgrad 100}}
-* Du tar ut {{prioritertUtbetalingsgrad}} prosent foreldrepenger fra og med {{periodeFom}} til og med {{periodeTom}} fordi den andre forelderen skal ta ut foreldrepenger i samme periode. I denne perioden får du {{periodeDagsats}} kroner per dag før skatt.
+* Du tar ut {{prioritertUtbetalingsgrad}} prosent foreldrepenger fra og med {{periodeFom}} til og med {{periodeTom}} fordi den andre forelderen skal ta ut foreldrepenger i samme periode. I denne perioden får du {{formaterKroner periodeDagsats}} kroner per dag før skatt.
 {{/neq}}{{/eq}}
 
 
@@ -62,7 +62,7 @@ Vi har redusert utbetalingen din fordi du jobber i denne perioden. Selv om du jo
 
 
 {{#if (and (eq arbeidsforholdsliste.0.gradering true) (eq innvilget true))}}
-* Du tar ut {{arbeidsforholdsliste.0.utbetalingsgrad}} prosent foreldrepenger fra og med {{periodeFom}} til og med {{periodeTom}} fordi du jobber {{arbeidsforholdsliste.0.stillingsprosent}} prosent hos {{arbeidsforholdsliste.0.arbeidsgiverNavn}}. I denne perioden får du {{periodeDagsats}} kroner per dag før skatt.
+* Du tar ut {{arbeidsforholdsliste.0.utbetalingsgrad}} prosent foreldrepenger fra og med {{periodeFom}} til og med {{periodeTom}} fordi du jobber {{arbeidsforholdsliste.0.stillingsprosent}} prosent hos {{arbeidsforholdsliste.0.arbeidsgiverNavn}}. I denne perioden får du {{formaterKroner periodeDagsats}} kroner per dag før skatt.
 {{#each arbeidsforholdsliste}}
 {{#if (and (eq this.prosentArbeid this.stillingsprosent) (lt this.stillingsprosent 100))}} {{#if (and (eq this.gradering false) (eq arbeidsforholdsliste.0.gradering true))}}
 Selv om du er tilbake i arbeid hos {{this.arbeidsgiverNavn}} har du fremdeles rett til foreldrepenger. Derfor får du fremdeles utbetalt foreldrepenger.
@@ -79,13 +79,13 @@ I samme periode tar du ut 100 prosent permisjon hos {{this.arbeidsgiverNavn}}.
 
 {{#each annenAktivitetsliste}}
 {{#if (and (eq this.aktivitetStatus "FL") (eq this.gradering true))}} {{#if @../innvilget}}
-* Du tar ut {{this.utbetalingsgrad}} prosent foreldrepenger fra og med {{@../periodeFom}} til og med {{@../periodeTom}} fordi du jobber {{this.prosentArbeid}} prosent. I denne perioden får du {{@../periodeDagsats}} kroner per dag før skatt.
+* Du tar ut {{this.utbetalingsgrad}} prosent foreldrepenger fra og med {{@../periodeFom}} til og med {{@../periodeTom}} fordi du jobber {{this.prosentArbeid}} prosent. I denne perioden får du {{formaterKroner @../periodeDagsats}} kroner per dag før skatt.
 {{/if}}{{/if}}
 {{/each}}
 
 
 {{#if (and (eq this.næring.gradering true) (eq this.innvilget true))}}
-* Du tar ut {{this.næring.utbetalingsgrad}} prosent foreldrepenger fra og med {{this.periodeFom}} til og med {{this.periodeTom}} fordi du jobber {{this.næring.prosentArbeid}} prosent. I denne perioden får du {{this.periodeDagsats}} kroner per dag før skatt.
+* Du tar ut {{this.næring.utbetalingsgrad}} prosent foreldrepenger fra og med {{this.periodeFom}} til og med {{this.periodeTom}} fordi du jobber {{this.næring.prosentArbeid}} prosent. I denne perioden får du {{formaterKroner this.periodeDagsats}} kroner per dag før skatt.
 {{/if}}
 
 

--- a/content/templates/innvilget-foreldrepenger/template_nb.hbs
+++ b/content/templates/innvilget-foreldrepenger/template_nb.hbs
@@ -1,13 +1,9 @@
 {{> header }}
 <br/>
 <br/>
-{{#if (and
-            (eq behandlingType "FØRSTEGANGSSØKNAD")
-            (eq behandlingResultatType "INNVILGET"))}}
+{{#if (and  (eq behandlingType "FØRSTEGANGSSØKNAD")(eq behandlingResultatType "INNVILGET"))}}
 # NAV har innvilget søknaden din om {{dekningsgrad}} prosent foreldrepenger
-{{else if (and
-            (eq behandlingResultatType "FORELDREPENGER_ENDRET")
-            (eq konsekvensForInnvilgetYtelse "ENDRING_I_BEREGNING"))}}
+{{else if (and (eq behandlingResultatType "FORELDREPENGER_ENDRET") (eq konsekvensForInnvilgetYtelse "ENDRING_I_BEREGNING"))}}
 # NAV har beregnet foreldrepengene dine på nytt
 {{else}}
 # NAV har endret foreldrepengeperioden din
@@ -18,7 +14,7 @@
 
 {{#if inkludereUtbetaling}}{{> innvilget-foreldrepenger/utbetaling_nb}}{{/if}}
 
-{{#eq konsekvensForInnvilgetYtelse "ENDRING_I_BEREGNING"}}Vi har fått nye inntektsopplysninger. Derfor har vi endret det du får utbetalt.{{#gt dagsats 0}}Du får {{dagsats}} kroner per dag før skatt. Dette er i gjennomsnitt {{månedsbeløp}} kroner i måneden. Sjekk utbetalingene dine på nav.no/utbetalinger
+{{#eq konsekvensForInnvilgetYtelse "ENDRING_I_BEREGNING"}}Vi har fått nye inntektsopplysninger. Derfor har vi endret det du får utbetalt.{{#gt dagsats 0}}Du får {{formaterKroner dagsats}} kroner per dag før skatt. Dette er i gjennomsnitt {{formaterKroner månedsbeløp}} kroner i måneden. Sjekk utbetalingene dine på nav.no/utbetalinger
 {{/gt}}
 {{/eq}}
 {{#if inkludereGradering}}{{> innvilget-foreldrepenger/gradering_nb}}{{/if}}
@@ -29,9 +25,7 @@
 
 {{#if barnErFødt gjelderMor årsakErFødselshendelse}}
 {{#gt dagerTaptFørTermin 0}}
-{{#if (or
-          (eq konsekvensForInnvilgetYtelse "ENDRING_I_UTTAK")
-          (eq konsekvensForInnvilgetYtelse "ENDRING_I_BEREGNING_OG_UTTAK"))}}
+{{#if (or (eq konsekvensForInnvilgetYtelse "ENDRING_I_UTTAK") (eq konsekvensForInnvilgetYtelse "ENDRING_I_BEREGNING_OG_UTTAK"))}}
 Vi har endret den siste dagen din med foreldrepenger til {{stønadsperiodeTom}}.
 
 Perioden med foreldrepenger starter tre uker før termin. Du fødte før termin, og derfor mister du {{dagerTaptFørTermin}} {{#gt dagerTaptFørTermin 1}}dager{{else}}dag{{/gt}} med foreldrepenger.
@@ -45,8 +39,7 @@ Vedtaket er gjort etter folketrygdloven {{lovhjemlerUttak}}.
 
 {{#neq konsekvensForInnvilgetYtelse "ENDRING_I_UTTAK"}}{{> innvilget-foreldrepenger/beregning_nb}}{{/neq}}
 
-{{#if inntektOverSeksG
-      (neq konsekvensForInnvilgetYtelse "ENDRING_I_UTTAK")}}
+{{#if inntektOverSeksG (neq konsekvensForInnvilgetYtelse "ENDRING_I_UTTAK")}}
 Foreldrepengene dine er fastsatt til {{seksG}} kroner i året, som er seks ganger grunnbeløpet i folketrygden. Du tjener mer enn dette, men du får ikke foreldrepenger for den delen av inntekten som overstiger seks ganger grunnbeløpet.
 {{/if}}
 
@@ -63,9 +56,7 @@ Beregningen er gjort etter folketrygdloven {{lovhjemlerBeregning}}.
 Hvis arbeidsgiver kommer med nye opplysninger om inntekten du hadde før du startet foreldrepengeperioden, får du et nytt vedtak med ny beregning.
 {{/if}}
 
-{{#if (or
-          (eq forMyeUtbetalt "FERIE")
-          (eq forMyeUtbetalt "JOBB"))}}
+{{#if (or (eq forMyeUtbetalt "FERIE")(eq forMyeUtbetalt "JOBB"))}}
 **Hva skjer hvis du får utbetalt foreldrepenger og lønn for samme periode?**
 
 Hvis du har fått utbetalt foreldrepenger samtidig som du har jobbet eller utsatt dager fordi du har hatt ferie, har du fått utbetalt for mye i foreldrepenger. Det betyr at utbetalingen i neste måned kan bli redusert med det du har fått utbetalt for mye.

--- a/content/templates/innvilget-foreldrepenger/testdata/beregning/revurdering_kun_ytelse_80_dg.json
+++ b/content/templates/innvilget-foreldrepenger/testdata/beregning/revurdering_kun_ytelse_80_dg.json
@@ -1,0 +1,90 @@
+{
+  "felles": {
+    "søkerNavn": "GRIS EMILY",
+    "søkerPersonnummer": "224293 10648",
+    "brevDato": "2. juni 2021",
+    "erAutomatiskBehandlet": false,
+    "erKopi": false,
+    "harVerge": false,
+    "saksnummer": "152001001",
+    "ytelseType": "FP"
+  },
+  "behandlingType": "REVURDERING",
+  "behandlingResultatType": "FORELDREPENGER_ENDRET",
+  "konsekvensForInnvilgetYtelse": "INGEN_ENDRING",
+  "søknadsdato": "2. juni 2021",
+  "dekningsgrad": 80,
+  "dagsats": 1200,
+  "månedsbeløp": 26000,
+  "seksG": 608106,
+  "inntektOverSeksG": false,
+  "inntektMottattArbeidsgiver": false,
+  "annenForelderHarRett": true,
+  "annenForelderHarRettVurdert": "IKKE_VURDERT",
+  "aleneomsorgKode": "IKKE_VURDERT",
+  "ikkeOmsorg": false,
+  "barnErFødt": true,
+  "årsakErFødselshendelse": false,
+  "gjelderMor": false,
+  "gjelderFødsel": true,
+  "erBesteberegning": false,
+  "ingenRefusjon": true,
+  "delvisRefusjon": false,
+  "fullRefusjon": false,
+  "fbEllerRvInnvilget": true,
+  "antallPerioder": 1,
+  "harInnvilgedePerioder": true,
+  "antallArbeidsgivere": 0,
+  "dagerTaptFørTermin": 0,
+  "disponibleDager": 0,
+  "disponibleFellesDager": 0,
+  "sisteDagAvSistePeriode": "21. desember 2021",
+  "stønadsperiodeFom": "28. april 2021",
+  "stønadsperiodeTom": "21. desember 2021",
+  "foreldrepengeperiodenUtvidetUker": 0,
+  "antallBarn": 1,
+  "prematurDager": 0,
+  "perioder": [
+    {
+      "innvilget": true,
+      "årsak": "2003",
+      "periodeFom": "28. april 2021",
+      "periodeTom": "21. desember 2021",
+      "periodeDagsats": 1200,
+      "antallTapteDager": 0,
+      "prioritertUtbetalingsgrad": 100,
+      "annenAktivitet": {
+        "aktivitetStatus": "BRUKERSANDEL",
+        "gradering": false,
+        "utbetalingsgrad": 100,
+        "prosentArbeid": 0
+      }
+    }
+  ],
+  "bruttoBeregningsgrunnlag": 390000,
+  "harBruktBruttoBeregningsgrunnlag": true,
+  "beregningsgrunnlagregler": [
+    {
+      "regelStatus": "KUN_YTELSE",
+      "antallArbeidsgivereIBeregningUtenEtterlønnSluttpakke": 0,
+      "snNyoppstartet": false,
+      "andelListe": [
+        {
+          "aktivitetStatus": "KUN_YTELSE",
+          "dagsats": 1391,
+          "månedsinntekt": 30137,
+          "årsinntekt": 361644,
+          "etterlønnSluttpakke": false,
+          "sistLignedeÅr": 2019
+        }
+      ]
+    }
+  ],
+  "klagefristUker": 6,
+  "lovhjemlerUttak": "§§ 14-9, 14-10 og 14-12",
+  "lovhjemlerBeregning": "§§ 14-7 og 8-35",
+  "inkludereUtbetaling": true,
+  "inkludereGradering": false,
+  "inkludereInnvilget": false,
+  "inkludereAvslag": false
+}

--- a/content/templates/innvilget-foreldrepenger/utbetaling_nb.hbs
+++ b/content/templates/innvilget-foreldrepenger/utbetaling_nb.hbs
@@ -1,5 +1,5 @@
 {{#neq stønadsperiodeFom ""}}
-Du får {{dagsats}} kroner per dag før skatt fra og med {{stønadsperiodeFom}}. Dette er i gjennomsnitt {{månedsbeløp}} kroner i måneden. Den siste dagen du får foreldrepenger er {{stønadsperiodeTom}}.
+Du får {{formaterKroner dagsats}} kroner per dag før skatt fra og med {{stønadsperiodeFom}}. Dette er i gjennomsnitt {{formaterKroner månedsbeløp}} kroner i måneden. Den siste dagen du får foreldrepenger er {{stønadsperiodeTom}}.
 {{/neq}}
 {{#if fbEllerRvInnvilget}}{{#if ingenRefusjon}}Foreldrepengene blir utbetalt for alle dager, unntatt lørdag og søndag. Fordi det ikke er like mange dager i hver måned, vil de månedlige utbetalingene dine variere.
 

--- a/src/test/java/no/nav/foreldrepenger/dokgen/test/support/DivideHelper.java
+++ b/src/test/java/no/nav/foreldrepenger/dokgen/test/support/DivideHelper.java
@@ -1,0 +1,18 @@
+package no.nav.foreldrepenger.dokgen.test.support;
+
+import com.github.jknack.handlebars.Helper;
+import com.github.jknack.handlebars.Options;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+
+public class DivideHelper implements Helper<Integer> {
+
+    @Override
+    public Object apply(final Integer antall, final Options options) {
+        Integer beløp = options.param(0);
+        BigDecimal value = BigDecimal.valueOf(beløp).divide(BigDecimal.valueOf(antall), 0, RoundingMode.HALF_UP);
+
+        return value.intValue();
+    }
+}

--- a/src/test/java/no/nav/foreldrepenger/dokgen/test/support/FormaterKronerHelper.java
+++ b/src/test/java/no/nav/foreldrepenger/dokgen/test/support/FormaterKronerHelper.java
@@ -1,0 +1,22 @@
+package no.nav.foreldrepenger.dokgen.test.support;
+
+import com.github.jknack.handlebars.Helper;
+import com.github.jknack.handlebars.Options;
+
+import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
+import java.text.NumberFormat;
+import java.util.Locale;
+
+public class FormaterKronerHelper implements Helper<Integer> {
+    @Override
+    public Object apply(Integer kroner, final Options options) {
+        DecimalFormat formatter = (DecimalFormat) NumberFormat.getInstance(Locale.US);
+        DecimalFormatSymbols symbols = formatter.getDecimalFormatSymbols();
+
+        symbols.setGroupingSeparator(' ');
+        formatter.setDecimalFormatSymbols(symbols);
+
+        return formatter.format(kroner.intValue());
+    }
+}

--- a/src/test/java/no/nav/foreldrepenger/dokgen/test/support/TemplateTestService.java
+++ b/src/test/java/no/nav/foreldrepenger/dokgen/test/support/TemplateTestService.java
@@ -1,9 +1,5 @@
 package no.nav.foreldrepenger.dokgen.test.support;
 
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.jknack.handlebars.Context;
@@ -17,6 +13,10 @@ import com.github.jknack.handlebars.context.MethodValueResolver;
 import com.github.jknack.handlebars.helper.ConditionalHelpers;
 import com.github.jknack.handlebars.helper.StringHelpers;
 import com.github.jknack.handlebars.io.FileTemplateLoader;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 public class TemplateTestService {
 
@@ -38,6 +38,8 @@ public class TemplateTestService {
         handlebars.registerHelper("switch", new SwitchHelper());
         handlebars.registerHelper("case", new CaseHelper());
         handlebars.registerHelper("add", new AdditionHelper());
+        handlebars.registerHelper("divide", new DivideHelper());
+        handlebars.registerHelper("formaterKroner", new FormaterKronerHelper());
         handlebars.registerHelpers(StringHelpers.class);
     }
 

--- a/src/test/java/no/nav/foreldrepenger/dokgen/test/templates/innvilgelsefp/InnvilgetForeldrepengerBeregningTest.java
+++ b/src/test/java/no/nav/foreldrepenger/dokgen/test/templates/innvilgelsefp/InnvilgetForeldrepengerBeregningTest.java
@@ -1,10 +1,9 @@
 package no.nav.foreldrepenger.dokgen.test.templates.innvilgelsefp;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
+import no.nav.foreldrepenger.dokgen.test.support.TemplateTestService;
 import org.junit.jupiter.api.Test;
 
-import no.nav.foreldrepenger.dokgen.test.support.TemplateTestService;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class InnvilgetForeldrepengerBeregningTest {
     private static final String TEMPLATE_NAME = "innvilget-foreldrepenger";
@@ -42,5 +41,13 @@ public class InnvilgetForeldrepengerBeregningTest {
         String resultat = templateTestService.compileTemplateWithTestData(TEMPLATE_NAME, TEMPLATE_PATH, "nb", "beregning/førstegangsbehandling_frilans");
         // Assert
         assertThat(resultat).isEqualToNormalizingWhitespace(templateTestService.getExpectedResult(TEMPLATE_NAME, EXPECTED_PREFIX + "frilans_nb.txt"));
+    }
+
+    @Test
+    public void undermal_beregning_fri_ytelse_80_dg_nb() throws Exception {
+        // Act
+        String resultat = templateTestService.compileTemplateWithTestData(TEMPLATE_NAME, TEMPLATE_PATH, "nb", "beregning/revurdering_kun_ytelse_80_dg");
+        // Assert
+        assertThat(resultat).isEqualToNormalizingWhitespace(templateTestService.getExpectedResult(TEMPLATE_NAME, EXPECTED_PREFIX + "kun_ytelse_nb.txt"));
     }
 }

--- a/src/test/resources/expected/innvilget-foreldrepenger/beregning/innvilget-foreldrepenger_enn_ag_nb.txt
+++ b/src/test/resources/expected/innvilget-foreldrepenger/beregning/innvilget-foreldrepenger_enn_ag_nb.txt
@@ -1,6 +1,28 @@
 <br/>
 
 **Inntekt vi har brukt i beregningen**
-Vi har brukt 574548 kroner i året før skatt i beregningen av foreldrepengene dine.
-Inntekten din hos STENDI AS REGION ØST CA MØRK er 47879 kroner i måneden. Arbeidsgiveren din har gitt oss disse opplysningene.
+
+
+Vi har brukt 574 548 kroner i året før skatt i beregningen av foreldrepengene dine.
+
+
+Inntekten din hos STENDI AS REGION ØST CA MØRK er 47 879 kroner i måneden. Arbeidsgiveren din har gitt oss disse opplysningene.
+
+
+
+
+
+
+
+
 Dette er gjennomsnittet av inntekten din fra de siste tre månedene. Hvis du nettopp har begynt å arbeide, byttet arbeidsforhold eller lønnen din har endret seg, har vi brukt månedsinntektene etter at endringen skjedde.
+
+
+
+
+
+
+
+
+
+

--- a/src/test/resources/expected/innvilget-foreldrepenger/beregning/innvilget-foreldrepenger_frilans_nb.txt
+++ b/src/test/resources/expected/innvilget-foreldrepenger/beregning/innvilget-foreldrepenger_frilans_nb.txt
@@ -1,5 +1,23 @@
 <br/>
 
 **Inntekt vi har brukt i beregningen**
-Inntekten din som frilanser er 47879 kroner i måneden.  Oppdragsgiveren eller oppdragsgiverne dine har gitt oss disse opplysningene.
+
+
+
+
+
+Inntekten din som frilanser er 47 879 kroner i måneden.  Oppdragsgiveren eller oppdragsgiverne dine har gitt oss disse opplysningene.
 Dette er gjennomsnittet av inntekten din fra de siste tre månedene. Hvis du nettopp har begynt å arbeide som frilanser, har vi brukt inntektene etter at du startet.
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/src/test/resources/expected/innvilget-foreldrepenger/beregning/innvilget-foreldrepenger_kun_ytelse_nb.txt
+++ b/src/test/resources/expected/innvilget-foreldrepenger/beregning/innvilget-foreldrepenger_kun_ytelse_nb.txt
@@ -1,0 +1,13 @@
+<br/>
+
+**Inntekt vi har brukt i beregningen**
+
+
+Vi har brukt 390 000 kroner i året før skatt i beregningen av foreldrepengene dine.
+
+
+
+
+
+Vi har beregnet foreldrepengene dine ut fra en inntekt på 32 500 kroner i måneden før skatt. Dette er gjennomsnittet av inntekten du har fått fra NAV de siste tre månedene.
+

--- a/src/test/resources/expected/innvilget-foreldrepenger/beregning/innvilget-foreldrepenger_næring_nb.txt
+++ b/src/test/resources/expected/innvilget-foreldrepenger/beregning/innvilget-foreldrepenger_næring_nb.txt
@@ -7,7 +7,7 @@
 
 
 
-Vi har beregnet foreldrepengene dine ut fra en årsinntekt på 540000 kroner. Dette er gjennomsnittet av inntekten du hadde i 2019, 2018 og 2017.
+Vi har beregnet foreldrepengene dine ut fra en årsinntekt på 540 000 kroner. Dette er gjennomsnittet av inntekten du hadde i 2019, 2018 og 2017.
 
 
 

--- a/src/test/resources/expected/innvilget-foreldrepenger/beregning/innvilget-foreldrepenger_to_ag_nb.txt
+++ b/src/test/resources/expected/innvilget-foreldrepenger/beregning/innvilget-foreldrepenger_to_ag_nb.txt
@@ -3,8 +3,37 @@
 **Inntekt vi har brukt i beregningen**
 
 
-Vi har brukt 574548 kroner i året før skatt i beregningen av foreldrepengene dine.
-Inntekten din hos STENDI AS REGION ØST CA MØRK er 47879 kroner i måneden.
-Inntekten din hos KATE AND ROB er 54321 kroner i måneden.
+Vi har brukt 574 548 kroner i året før skatt i beregningen av foreldrepengene dine.
+
+
+
+Inntekten din hos STENDI AS REGION ØST CA MØRK er 47 879 kroner i måneden.
+
+
+
+
+
+Inntekten din hos KATE AND ROB er 54 321 kroner i måneden.
+
+
+
+
 Arbeidsgiverne dine har gitt oss disse opplysningene.
+
+
+
+
+
+
 Dette er gjennomsnittet av inntekten din fra de siste tre månedene. Hvis du nettopp har begynt å arbeide, byttet arbeidsforhold eller lønnen din har endret seg, har vi brukt månedsinntektene etter at endringen skjedde.
+
+
+
+
+
+
+
+
+
+
+

--- a/src/test/resources/expected/innvilget-foreldrepenger/innvilget-foreldrepenger_template_forstegangsbehandling_med_avslag_nb.txt
+++ b/src/test/resources/expected/innvilget-foreldrepenger/innvilget-foreldrepenger_template_forstegangsbehandling_med_avslag_nb.txt
@@ -22,7 +22,7 @@ Fødselsnummer: 300220 12345
 
 
 
-Du får 1618 kroner per dag før skatt fra og med 4. juni 2022. Dette er i gjennomsnitt 35056 kroner i måneden. Den siste dagen du får foreldrepenger er 4. november 2022.
+Du får 1 618 kroner per dag før skatt fra og med 4. juni 2022. Dette er i gjennomsnitt 35 056 kroner i måneden. Den siste dagen du får foreldrepenger er 4. november 2022.
 
 
 Arbeidsgiverne dine betaler deg lønn mens du har permisjon. Resten av foreldrepengene får du utbetalt fra NAV innen den 25. hver måned. Sjekk utbetalingene dine på [nav.no/utbetalinger](https://nav.no/utbetalinger).
@@ -112,7 +112,7 @@ Du jobber hos flere arbeidsgivere i samme periode. Det er kun mulig å kombinere
 
 
 
-* Du tar ut 20 prosent foreldrepenger fra og med 24. februar 2021 til og med 26. mars 2021 fordi du jobber 80 prosent hos SYKEHUSET TELEMARK HF NOTODDEN - SOMATIKK. I denne perioden får du 1618 kroner per dag før skatt.
+* Du tar ut 20 prosent foreldrepenger fra og med 24. februar 2021 til og med 26. mars 2021 fordi du jobber 80 prosent hos SYKEHUSET TELEMARK HF NOTODDEN - SOMATIKK. I denne perioden får du 1 618 kroner per dag før skatt.
 
 
 
@@ -153,7 +153,7 @@ I samme periode tar du ut 100 prosent permisjon hos SYKEHUSET TELEMARK HF SKIEN 
 
 
 
-* Du tar ut foreldrepenger fra og med 29. mars 2021 til og med 05. mai 2020. I denne perioden får du 1939 kroner per dag før skatt.
+* Du tar ut foreldrepenger fra og med 29. mars 2021 til og med 05. mai 2020. I denne perioden får du 1 939 kroner per dag før skatt.
 
 
 
@@ -227,7 +227,7 @@ I samme periode tar du ut 100 prosent permisjon hos SYKEHUSET TELEMARK HF SKIEN 
 
 
 
-* Du tar ut 20 prosent foreldrepenger fra og med 06. april 2021 til og med 06. juni 2021 fordi du jobber 80 prosent hos SYKEHUSET TELEMARK HF NOTODDEN - SOMATIKK. I denne perioden får du 1618 kroner per dag før skatt.
+* Du tar ut 20 prosent foreldrepenger fra og med 06. april 2021 til og med 06. juni 2021 fordi du jobber 80 prosent hos SYKEHUSET TELEMARK HF NOTODDEN - SOMATIKK. I denne perioden får du 1 618 kroner per dag før skatt.
 
 
 
@@ -561,17 +561,17 @@ Vedtaket er gjort etter folketrygdloven §§ 14-9, 14-12 og 14-16.
 **Inntekt vi har brukt i beregningen**
 
 
-Vi har brukt 504360 kroner i året før skatt i beregningen av foreldrepengene dine.
+Vi har brukt 504 360 kroner i året før skatt i beregningen av foreldrepengene dine.
 
 
 
-Inntekten din hos SYKEHUSET TELEMARK HF NOTODDEN - SOMATIKK er 8697 kroner i måneden.
+Inntekten din hos SYKEHUSET TELEMARK HF NOTODDEN - SOMATIKK er 8 697 kroner i måneden.
 
 
 
 
 
-Inntekten din hos SYKEHUSET TELEMARK HF SKIEN - SOMATIKK er 33333 kroner i måneden.
+Inntekten din hos SYKEHUSET TELEMARK HF SKIEN - SOMATIKK er 33 333 kroner i måneden.
 
 
 

--- a/src/test/resources/expected/innvilget-foreldrepenger/innvilget-foreldrepenger_template_forstegangsbehandling_nb.txt
+++ b/src/test/resources/expected/innvilget-foreldrepenger/innvilget-foreldrepenger_template_forstegangsbehandling_nb.txt
@@ -22,7 +22,7 @@ Fødselsnummer: 300220 12345
 
 
 
-Du får 2209 kroner per dag før skatt fra og med 4. juni 2022. Dette er i gjennomsnitt 47879 kroner i måneden. Den siste dagen du får foreldrepenger er 4. november 2022.
+Du får 2 209 kroner per dag før skatt fra og med 4. juni 2022. Dette er i gjennomsnitt 47 879 kroner i måneden. Den siste dagen du får foreldrepenger er 4. november 2022.
 
 Foreldrepengene blir utbetalt for alle dager, unntatt lørdag og søndag. Fordi det ikke er like mange dager i hver måned, vil de månedlige utbetalingene dine variere.
 
@@ -65,7 +65,7 @@ Pengene er på kontoen din innen den 25. hver måned. Sjekk utbetalingene dine p
 
 
 
-* Du tar ut foreldrepenger fra og med 15. april 2021 til og med 18. august 2021. I denne perioden får du 2209 kroner per dag før skatt.
+* Du tar ut foreldrepenger fra og med 15. april 2021 til og med 18. august 2021. I denne perioden får du 2 209 kroner per dag før skatt.
 
 
 
@@ -169,7 +169,7 @@ Pengene er på kontoen din innen den 25. hver måned. Sjekk utbetalingene dine p
 
 
 
-* Du tar ut foreldrepenger fra og med 27. september 2021 til og med 25. november 2021. I denne perioden får du 2209 kroner per dag før skatt.
+* Du tar ut foreldrepenger fra og med 27. september 2021 til og med 25. november 2021. I denne perioden får du 2 209 kroner per dag før skatt.
 
 
 
@@ -220,7 +220,7 @@ Pengene er på kontoen din innen den 25. hver måned. Sjekk utbetalingene dine p
 
 
 
-* Du tar ut 80 prosent foreldrepenger fra og med 26. november 2021 til og med 17. januar 2022. I denne perioden får du 1768 kroner per dag før skatt.
+* Du tar ut 80 prosent foreldrepenger fra og med 26. november 2021 til og med 17. januar 2022. I denne perioden får du 1 768 kroner per dag før skatt.
 
 
 
@@ -278,11 +278,10 @@ Vedtaket er gjort etter folketrygdloven § forvaltningsloven § 35.
 **Inntekt vi har brukt i beregningen**
 
 
-Vi har brukt 574548 kroner i året før skatt i beregningen av foreldrepengene dine.
+Vi har brukt 574 548 kroner i året før skatt i beregningen av foreldrepengene dine.
 
 
-Inntekten din hos STENDI AS REGION ØST CA MØRK er 47879 kroner i måneden. Arbeidsgiveren din har gitt oss disse opplysningene.
-
+Inntekten din hos STENDI AS REGION ØST CA MØRK er 47 879 kroner i måneden. Arbeidsgiveren din har gitt oss disse opplysningene.
 
 
 

--- a/src/test/resources/expected/innvilget-foreldrepenger/innvilget/innvilget-foreldrepenger_annenaktivitet_næring_nb.txt
+++ b/src/test/resources/expected/innvilget-foreldrepenger/innvilget/innvilget-foreldrepenger_annenaktivitet_næring_nb.txt
@@ -157,7 +157,7 @@
 
 
 
-* Du tar ut 70 prosent foreldrepenger fra og med 21. august 2021 til og med 22. august 2021 fordi du jobber 85 prosent. I denne perioden får du 700 kroner per dag før skatt.
+* Du tar ut 70 prosent foreldrepenger fra og med 21. august 2021 til og med 22. august 2021 fordi du jobber 85 prosent. I denne perioden får du  700 kroner per dag før skatt.
 
 
 

--- a/src/test/resources/expected/innvilget-foreldrepenger/innvilget/innvilget-foreldrepenger_enkeltårsaker_nb.txt
+++ b/src/test/resources/expected/innvilget-foreldrepenger/innvilget/innvilget-foreldrepenger_enkeltårsaker_nb.txt
@@ -237,7 +237,7 @@ Vi har redusert utbetalingen din fordi du jobber i denne perioden. Selv om du jo
 
 
 
-* Du tar ut 50 prosent foreldrepenger fra og med 9. april 2021 til og med 10. april 2021 fordi den andre forelderen skal ta ut foreldrepenger i samme periode. I denne perioden får du 1001 kroner per dag før skatt.
+* Du tar ut 50 prosent foreldrepenger fra og med 9. april 2021 til og med 10. april 2021 fordi den andre forelderen skal ta ut foreldrepenger i samme periode. I denne perioden får du 1 001 kroner per dag før skatt.
 
 
 

--- a/src/test/resources/expected/innvilget-foreldrepenger/innvilget/innvilget-foreldrepenger_fullt_nb.txt
+++ b/src/test/resources/expected/innvilget-foreldrepenger/innvilget/innvilget-foreldrepenger_fullt_nb.txt
@@ -12,7 +12,7 @@
 
 
 
-* Du tar ut foreldrepenger fra og med 15. april 2021 til og med 18. august 2021. I denne perioden får du 1000 kroner per dag før skatt.
+* Du tar ut foreldrepenger fra og med 15. april 2021 til og med 18. august 2021. I denne perioden får du 1 000 kroner per dag før skatt.
 
 
 
@@ -63,7 +63,7 @@
 
 
 
-* Du tar ut foreldrepenger fra og med 19. august 2021 til og med 24. september 2021. I denne perioden får du 1200 kroner per dag før skatt.
+* Du tar ut foreldrepenger fra og med 19. august 2021 til og med 24. september 2021. I denne perioden får du 1 200 kroner per dag før skatt.
 
 
 

--- a/src/test/resources/expected/innvilget-foreldrepenger/utbetaling/innvilget-foreldrepenger_utbetaling_delvis_refusjon_nb.txt
+++ b/src/test/resources/expected/innvilget-foreldrepenger/utbetaling/innvilget-foreldrepenger_utbetaling_delvis_refusjon_nb.txt
@@ -1,5 +1,4 @@
-
-Du får 2209 kroner per dag før skatt fra og med 4. juni 2022. Dette er i gjennomsnitt 47879 kroner i måneden. Den siste dagen du får foreldrepenger er 4. november 2022.
+Du får 2 209 kroner per dag før skatt fra og med 4. juni 2022. Dette er i gjennomsnitt 47 879 kroner i måneden. Den siste dagen du får foreldrepenger er 4. november 2022.
 
 
 Arbeidsgiveren din betaler deg lønn mens du har permisjon. Resten av foreldrepengene får du utbetalt fra NAV innen den 25. hver måned. Sjekk utbetalingene dine på [nav.no/utbetalinger](https://nav.no/utbetalinger).

--- a/src/test/resources/expected/innvilget-foreldrepenger/utbetaling/innvilget-foreldrepenger_utbetaling_full_refusjon_nb.txt
+++ b/src/test/resources/expected/innvilget-foreldrepenger/utbetaling/innvilget-foreldrepenger_utbetaling_full_refusjon_nb.txt
@@ -1,5 +1,4 @@
-
-Du får 2209 kroner per dag før skatt fra og med 4. juni 2022. Dette er i gjennomsnitt 47879 kroner i måneden. Den siste dagen du får foreldrepenger er 4. november 2022.
+Du får 2 209 kroner per dag før skatt fra og med 4. juni 2022. Dette er i gjennomsnitt 47 879 kroner i måneden. Den siste dagen du får foreldrepenger er 4. november 2022.
 
 
 Vi utbetaler foreldrepengene til arbeidsgiverne dine fordi du får lønn mens du har permisjon.

--- a/src/test/resources/expected/innvilget-foreldrepenger/utbetaling/innvilget-foreldrepenger_utbetaling_ingen_refusjon_nb.txt
+++ b/src/test/resources/expected/innvilget-foreldrepenger/utbetaling/innvilget-foreldrepenger_utbetaling_ingen_refusjon_nb.txt
@@ -1,5 +1,24 @@
-Du får 2209 kroner per dag før skatt fra og med 4. juni 2022. Dette er i gjennomsnitt 47879 kroner i måneden. Den siste dagen du får foreldrepenger er 4. november 2022.
+Du får 2 209 kroner per dag før skatt fra og med 4. juni 2022. Dette er i gjennomsnitt 47 879 kroner i måneden. Den siste dagen du får foreldrepenger er 4. november 2022.
 
 Foreldrepengene blir utbetalt for alle dager, unntatt lørdag og søndag. Fordi det ikke er like mange dager i hver måned, vil de månedlige utbetalingene dine variere.
 
 Pengene er på kontoen din innen den 25. hver måned. Sjekk utbetalingene dine på [nav.no/utbetalinger](https://nav.no/utbetalinger).
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+


### PR DESCRIPTION
…% dekningsgrad.

TFP-4386 Rettet også at beløp som vises er formatert med mellomrom.