### PR TITLE
TFP-4419 Innvilget-foreldrepenger: lagt inn manglende sjekk på at and…

### DIFF
--- a/content/templates/innvilget-foreldrepenger/avslag_nb.hbs
+++ b/content/templates/innvilget-foreldrepenger/avslag_nb.hbs
@@ -43,7 +43,7 @@ Du kan ikke utsette foreldrepengene fra og med {{periodeFom}} til og med {{perio
 {{/case}}
 {{~#case "4037"}}
 {{#if (and (lt periodeDagsats dagsats)(gt periodeDagsats 0))}}
-Du kan ikke utsette foreldrepengene fra og med {{periodeFom}} til og med {{periodeTom}} fordi du ikke jobber heltid. Vi har derfor redusert foreldrepengene dine til {{periodeDagsats}} kroner per dag før skatt.
+Du kan ikke utsette foreldrepengene fra og med {{periodeFom}} til og med {{periodeTom}} fordi du ikke jobber heltid. Vi har derfor redusert foreldrepengene dine til {{format-kroner periodeDagsats}} kroner per dag før skatt.
 {{/if}}
 {{#eq periodeDagsats 0 }}
 Du kan ikke utsette foreldrepengene fra og med {{periodeFom}} til og med {{periodeTom}} fordi du ikke jobber heltid. Du får ikke foreldrepenger i denne perioden.

--- a/content/templates/innvilget-foreldrepenger/beregning_nb.hbs
+++ b/content/templates/innvilget-foreldrepenger/beregning_nb.hbs
@@ -7,7 +7,7 @@ Vi har brukt {{format-kroner bruttoBeregningsgrunnlag}} kroner i året før skat
 {{/eq}}
 
 {{~#if erBesteberegning}}
-Vi har fastsatt foreldrepengene dine til {{dagsats}} kroner per dag før skatt. Du har både jobbet og mottatt dagpenger. Vi har beregnet foreldrepengene dine ut fra de seks beste av de siste ti månedene.
+Vi har fastsatt foreldrepengene dine til {{format-kroner dagsats}} kroner per dag før skatt. Du har både jobbet og mottatt dagpenger. Vi har beregnet foreldrepengene dine ut fra de seks beste av de siste ti månedene.
 {{else}}
 
 {{~#each beregningsgrunnlagregler}}
@@ -58,16 +58,17 @@ Vi har beregnet foreldrepengene dine ut fra en årsinntekt på {{format-kroner t
 {{else}}
 Vi har fastsatt foreldrepengene dine til {{format-kroner this.årsinntekt}} kroner i året. Fordi du har begynt å jobbe i løpet av de tre siste årene, har vi beregnet inntekten din ut fra de opplysningene vi har for det siste året.
 {{/eq}}
-{{~#if (eq @../regelStatus "KOMBINERT_AT_SN")}}
+{{/eq}}
+{{~#if (and (eq @../regelStatus "KOMBINERT_AT_SN")(eq this.aktivitetStatus "SELVSTENDIG_NÆRINGSDRIVENDE"))}}
 Næringsinntekten din er fastsatt til {{format-kroner this.årsinntekt}} kroner i året. Når vi beregner foreldrepenger ut fra næringsinntekten din, bruker vi gjennomsnittet av de siste tre årene vi har fått oppgitt av Skatteetaten. Hvis du nettopp har begynt å arbeide, bruker vi inntekten vi har fått opplyst for det siste året. Dette gjennomsnittet kan også inneholde arbeidsinntekten din. De er trukket fra i beregningen av næringsinntekten.
 {{/if}}
-{{~#if (eq @../regelStatus "KOMBINERT_FL_SN")}}
+{{~#if (and (eq @../regelStatus "KOMBINERT_FL_SN")(eq this.aktivitetStatus "SELVSTENDIG_NÆRINGSDRIVENDE"))}}
 Næringsinntekten din er fastsatt til {{format-kroner this.årsinntekt}} kroner i året. Når vi beregner foreldrepenger ut fra næringsinntekten din, bruker vi gjennomsnittet av de siste tre årene vi har fått oppgitt av Skatteetaten. Hvis du nettopp har begynt å arbeide, bruker vi inntekten vi har fått opplyst for det siste året. Dette gjennomsnittet kan også inneholde inntekten din som frilanser. Den er trukket fra i beregningen av næringsinntekten.
 {{/if}}
-{{~#if (eq @../regelStatus "KOMBINERT_AT_FL_SN")}}
+{{~#if (and (eq @../regelStatus "KOMBINERT_AT_FL_SN")(eq this.aktivitetStatus "SELVSTENDIG_NÆRINGSDRIVENDE"))}}
 Næringsinntekten din er fastsatt til {{format-kroner this.årsinntekt}} kroner i året. Når vi beregner foreldrepenger ut fra næringsinntekten din, bruker vi gjennomsnittet av de siste tre årene vi har fått oppgitt av Skatteetaten. Hvis du nettopp har begynt å arbeide, bruker vi inntekten vi har fått opplyst for det siste året. Dette gjennomsnittet kan også inneholde arbeidsinntekten din og inntekten din som frilanser. De er trukket fra i beregningen av næringsinntekten.
 {{/if}}
-{{/eq}}
+
 {{/each}}
 {{/if}}
 

--- a/content/templates/innvilget-foreldrepenger/gradering_nb.hbs
+++ b/content/templates/innvilget-foreldrepenger/gradering_nb.hbs
@@ -1,10 +1,3 @@
-{{#neq sisteDagAvSistePeriode ""}}
-{{#gt disponibleDager 0}}
-Det er {{disponibleDager}} {{#gt disponibleDager 1}}dager{{else}}dagen{{/gt}} igjen av perioden med foreldrepenger. {{#gt disponibleDager 1}}Disse dagene{{else}}Denne dagen{{/gt}} må du søke om innen {{sisteDagAvSistePeriode}}.
-{{/gt}}
-{{~#if (or (gt disponibleDager 0)(gt disponibleFellesDager 0))}}{{~#if annenForelderHarRett (neq aleneomsorgKode "JA")}}
-Det er {{disponibleDager}} {{#eq disponibleDager 1}}dag{{else}}dager{{/eq}} igjen av kvoten din, og {{disponibleFellesDager}} {{#eq disponibleFellesDager 1}}dag{{else}}dager{{/eq}} som dere begge kan ta ut. {{#eq disponibleDager 1}}Denne dagene{{else}}Disse dagene{{/eq}} må det søkes om innen {{sisteDagAvSistePeriode}}.
-{{/if}}{{/if}}{{/neq}}
 {{#gt antallArbeidsgivere 1}}
 {{~#each perioder}}
 {{#if @first}}

--- a/content/templates/innvilget-foreldrepenger/template_nb.hbs
+++ b/content/templates/innvilget-foreldrepenger/template_nb.hbs
@@ -17,6 +17,12 @@
 {{#eq konsekvensForInnvilgetYtelse "ENDRING_I_BEREGNING"}}Vi har fått nye inntektsopplysninger. Derfor har vi endret det du får utbetalt.{{#gt dagsats 0}}Du får {{format-kroner dagsats}} kroner per dag før skatt. Dette er i gjennomsnitt {{format-kroner månedsbeløp}} kroner i måneden. Sjekk utbetalingene dine på nav.no/utbetalinger
 {{/gt}}
 {{/eq}}
+
+{{#neq sisteDagAvSistePeriode ""}}
+{{~#if (or (gt disponibleDager 0)(gt disponibleFellesDager 0))}}{{~#if annenForelderHarRett (neq aleneomsorgKode "JA")}}
+Det er {{disponibleDager}} {{#eq disponibleDager 1}}dag{{else}}dager{{/eq}} igjen av kvoten din, og {{disponibleFellesDager}} {{#eq disponibleFellesDager 1}}dag{{else}}dager{{/eq}} som dere begge kan ta ut. {{#eq disponibleDager 1}}Denne dagene{{else}}Disse dagene{{/eq}} må det søkes om innen {{sisteDagAvSistePeriode}}.
+{{/if}}{{/if}}{{/neq}}
+
 {{#if inkludereGradering}}{{> innvilget-foreldrepenger/gradering_nb}}{{/if}}
 
 {{#if inkludereInnvilget}}{{> innvilget-foreldrepenger/innvilget_nb}}{{/if}}
@@ -47,7 +53,7 @@ Vedtaket er gjort etter folketrygdloven {{lovhjemlerUttak}}.
 {{/neq}}
 
 {{#if inntektOverSeksG (neq konsekvensForInnvilgetYtelse "ENDRING_I_UTTAK")}}
-Foreldrepengene dine er fastsatt til {{seksG}} kroner i året, som er seks ganger grunnbeløpet i folketrygden. Du tjener mer enn dette, men du får ikke foreldrepenger for den delen av inntekten som overstiger seks ganger grunnbeløpet.
+Foreldrepengene dine er fastsatt til {{format-kroner seksG}} kroner i året, som er seks ganger grunnbeløpet i folketrygden. Du tjener mer enn dette, men du får ikke foreldrepenger for den delen av inntekten som overstiger seks ganger grunnbeløpet.
 {{/if}}
 
 {{#eq dekningsgrad 80}}

--- a/content/templates/innvilget-foreldrepenger/utbetaling_nb.hbs
+++ b/content/templates/innvilget-foreldrepenger/utbetaling_nb.hbs
@@ -32,3 +32,8 @@ Vi har forlenget foreldrepengeperioden med {{foreldrepengeperiodenUtvidetUker}} 
 
 {{#gt dagerTaptFørTermin 0}}{{#if fbEllerRvInnvilget gjelderFødsel}}Fordi du fødte før termin, mister du {{dagerTaptFørTermin}} {{#gt dagerTaptFørTermin 1}}dager{{else}}dag med foreldrepenger{{/gt}}.{{/if}}{{/gt}}
 
+{{#neq sisteDagAvSistePeriode ""}}
+{{#gt disponibleDager 0}}
+Det er {{disponibleDager}} {{#gt disponibleDager 1}}dager{{else}}dagen{{/gt}} igjen av perioden med foreldrepenger. {{#gt disponibleDager 1}}Disse dagene{{else}}Denne dagen{{/gt}} må du søke om innen {{sisteDagAvSistePeriode}}.
+{{/gt}}
+{{/neq}}

--- a/src/test/resources/expected/innvilget-foreldrepenger/gradering/innvilget-foreldrepenger_førstegangsbehandling_gradering_nb.txt
+++ b/src/test/resources/expected/innvilget-foreldrepenger/gradering/innvilget-foreldrepenger_førstegangsbehandling_gradering_nb.txt
@@ -1,17 +1,1 @@
-
-
-Det er 25 dager igjen av perioden med foreldrepenger. Disse dagene må du søke om innen 14. desember 2021.
-
-Det er 25 dager igjen av kvoten din, og 10 dager som dere begge kan ta ut. Disse dagene må det søkes om innen 14. desember 2021.
-
-
-
 Du jobber hos flere arbeidsgivere i samme periode. Det er kun mulig å kombinere foreldrepenger med arbeid hos én arbeidsgiver om gangen. Det betyr at det bare er perioden din hos TULLE TRANSPORT AS som blir forlenget.
-
-
-
-
-
-
-
-

--- a/src/test/resources/expected/innvilget-foreldrepenger/innvilget-foreldrepenger_template_forstegangsbehandling_med_avslag_nb.txt
+++ b/src/test/resources/expected/innvilget-foreldrepenger/innvilget-foreldrepenger_template_forstegangsbehandling_med_avslag_nb.txt
@@ -48,7 +48,11 @@ Arbeidsgiverne dine betaler deg lønn mens du har permisjon. Resten av foreldrep
 
 
 
+
+
+
 Det er 0 dager igjen av kvoten din, og 10 dager som dere begge kan ta ut. Disse dagene må det søkes om innen 4. november 2022.
+
 
 
 
@@ -586,6 +590,7 @@ Arbeidsgiverne dine har gitt oss disse opplysningene.
 
 
 Dette er gjennomsnittet av inntekten din fra de siste tre månedene. Hvis du nettopp har begynt å arbeide, byttet arbeidsforhold eller lønnen din har endret seg, har vi brukt månedsinntektene etter at endringen skjedde.
+
 
 
 

--- a/src/test/resources/expected/innvilget-foreldrepenger/innvilget-foreldrepenger_template_forstegangsbehandling_med_fritekst_nb.txt
+++ b/src/test/resources/expected/innvilget-foreldrepenger/innvilget-foreldrepenger_template_forstegangsbehandling_med_fritekst_nb.txt
@@ -48,6 +48,16 @@ Pengene er på kontoen din innen den 25. hver måned. Sjekk utbetalingene dine p
 
 
 
+Det er 7 dager igjen av perioden med foreldrepenger. Disse dagene må du søke om innen 29. juli 2022.
+
+
+
+
+
+
+
+Det er 7 dager igjen av kvoten din, og 0 dager som dere begge kan ta ut. Disse dagene må det søkes om innen 29. juli 2022.
+
 
 
 
@@ -279,7 +289,6 @@ Vedtaket er gjort etter folketrygdloven §§ 14-11 og 14-12.
 
 
 
-
 **Inntekt vi har brukt i beregningen**<br/>
 Inntekten din hos Arbeidsgiver 1 er oppgitt av din arbeidsgiver etter
 18.496 kroner i måneden.
@@ -292,6 +301,7 @@ Siden denne inntekten avviker med mer enn 25 prosent i forhold til din inntekt d
 
 Vi har fastsatt foreldrepengene dine etter gjennomsnittet av inntekten du har hatt i siste
 12 måneder.  Du får foreldrepenger etter en inntekt på 37.280 kroner i måneden.
+
 
 
 

--- a/src/test/resources/expected/innvilget-foreldrepenger/innvilget-foreldrepenger_template_forstegangsbehandling_nb.txt
+++ b/src/test/resources/expected/innvilget-foreldrepenger/innvilget-foreldrepenger_template_forstegangsbehandling_nb.txt
@@ -51,6 +51,14 @@ Pengene er på kontoen din innen den 25. hver måned. Sjekk utbetalingene dine p
 
 
 
+
+
+
+Det er 0 dager igjen av kvoten din, og 10 dager som dere begge kan ta ut. Disse dagene må det søkes om innen 4. november 2022.
+
+
+
+
 <br/>
 
 **Dette har vi innvilget**
@@ -293,6 +301,7 @@ Inntekten din hos STENDI AS REGION ØST CA MØRK er 47 879 kroner i måneden. Ar
 
 
 Dette er gjennomsnittet av inntekten din fra de siste tre månedene. Hvis du nettopp har begynt å arbeide, byttet arbeidsforhold eller lønnen din har endret seg, har vi brukt månedsinntektene etter at endringen skjedde.
+
 
 
 


### PR DESCRIPTION
…elens status=selvstendig_næringsdrivende for tekst om næringsinntekt, og endret slik at tekst om næringsinntekt vises riktig

TFP-4386 Innvilget-foreldrepenger: lagt inn formatering på kronebeløp for seksG og dagsats ved besteberegning
TFP-4374 Innvilget-foreldrepenger: Endret når tekst for gjenstående dager vises