### PR TITLE
TFP-4433 innvilget-foreldrepenger: Rettet slik at tekst vedrørende da…

### DIFF
--- a/content/templates/innvilget-foreldrepenger/testdata/førstegangsbehandling_automatisk_ingen_gradering_ingen_avslag.json
+++ b/content/templates/innvilget-foreldrepenger/testdata/førstegangsbehandling_automatisk_ingen_gradering_ingen_avslag.json
@@ -33,7 +33,7 @@
   "antallPerioder": 4,
   "harInnvilgedePerioder": true,
   "antallArbeidsgivere": 1,
-  "dagerTaptFørTermin": 0,
+  "dagerTaptFørTermin": 3,
   "disponibleDager": 0,
   "disponibleFellesDager": 10,
   "sisteDagAvSistePeriode": "4. november 2022",

--- a/content/templates/innvilget-foreldrepenger/utbetaling_nb.hbs
+++ b/content/templates/innvilget-foreldrepenger/utbetaling_nb.hbs
@@ -30,4 +30,4 @@ Vi har forlenget foreldrepengeperioden med {{foreldrepengeperiodenUtvidetUker}} 
 
 {{#each perioder}}{{#eq årsak "4095"}}Perioden med foreldrepenger starter tre uker før termin. Du har ikke tatt ut foreldrepenger fra og med {{periodeFom}} til og med {{periodeTom}}. Derfor mister du {{#gt antallTapteDager 1}}disse dagene{{else}}denne dagen{{/gt}}.{{/eq}}{{/each}}
 
-{{#gt dagerTaptFørTermin 0}}{{#if fbEllerRvInnvilget gjelderFødsel}}Fordi du fødte før termin, mister du {{dagerTaptFørTermin}} {{#gt dagerTaptFørTermin 1}}dager{{else}}dag med foreldrepenger{{/gt}}.{{/if}}{{/gt}}
+{{#gt dagerTaptFørTermin 0}}{{#if fbEllerRvInnvilget gjelderFødsel}}Fordi du fødte før termin, mister du {{dagerTaptFørTermin}} {{#gt dagerTaptFørTermin 1}}dager{{else}}dag{{/gt}} med foreldrepenger.{{/if}}{{/gt}}

--- a/src/test/resources/expected/innvilget-foreldrepenger/innvilget-foreldrepenger_template_forstegangsbehandling_nb.txt
+++ b/src/test/resources/expected/innvilget-foreldrepenger/innvilget-foreldrepenger_template_forstegangsbehandling_nb.txt
@@ -47,7 +47,7 @@ Pengene er på kontoen din innen den 25. hver måned. Sjekk utbetalingene dine p
 
 
 
-
+Fordi du fødte før termin, mister du 3 dager med foreldrepenger.
 
 <br/>
 


### PR DESCRIPTION
…gertaptFørTermin ble "Fordi du fødte før termin, mister du 13 dager med foreldrepenger."