### PR TITLE
Rettet feil på Innvilget-foreldrepenger - avslagsundermal.

### DIFF
--- a/content/templates/innvilget-foreldrepenger/avslag/ikke_seks_uker_født_nb.hbs
+++ b/content/templates/innvilget-foreldrepenger/avslag/ikke_seks_uker_født_nb.hbs
@@ -1,1 +1,1 @@
-Du kan ikke utsette foreldrepengene fra og med {{periodeFom}} til og med {{periodeFom}} fordi det ikke har gått seks uker siden {{#gt antallBarn 1}}barnet ditt{{else}}barna dine{{/gt}} ble født. Du får derfor utbetalt foreldrepenger i perioden.
+Du kan ikke utsette foreldrepengene fra og med {{periodeFom}} til og med {{periodeFom}} fordi det ikke har gått seks uker siden {{#gt antallBarn 1}}barna dine{{else}}barnet ditt{{/gt}} ble født. Du får derfor utbetalt foreldrepenger i perioden.

--- a/src/test/resources/expected/innvilget-foreldrepenger/avslag/innvilget-foreldrepenger_førstegangsbehandling_avslag_nb.txt
+++ b/src/test/resources/expected/innvilget-foreldrepenger/avslag/innvilget-foreldrepenger_førstegangsbehandling_avslag_nb.txt
@@ -673,7 +673,7 @@ Du har ikke søkt om å kombinere foreldrepengene med arbeid og derfor har vi re
 
 
 
-Du kan ikke utsette foreldrepengene fra og med 26. november 2021 til og med 26. november 2021 fordi det ikke har gått seks uker siden barna dine ble født. Du får derfor utbetalt foreldrepenger i perioden.
+Du kan ikke utsette foreldrepengene fra og med 26. november 2021 til og med 26. november 2021 fordi det ikke har gått seks uker siden barnet ditt ble født. Du får derfor utbetalt foreldrepenger i perioden.
 
 
 
@@ -723,7 +723,7 @@ Du kan ikke utsette foreldrepengene fra og med 26. november 2021 til og med 26. 
 
 
 
-Du kan ikke utsette foreldrepengene fra og med 26. november 2021 til og med 26. november 2021 fordi det ikke har gått seks uker siden barna dine ble født. Du får derfor utbetalt foreldrepenger i perioden.
+Du kan ikke utsette foreldrepengene fra og med 26. november 2021 til og med 26. november 2021 fordi det ikke har gått seks uker siden barnet ditt ble født. Du får derfor utbetalt foreldrepenger i perioden.
 
 
 


### PR DESCRIPTION
Rettet at test på antall barn ved avslag på utsettelse pga ikke seks uker siden fødsel ga feil tekst (barna dine/barnet ditt).