### PR TITLE
TFP-4502 Rettet feil ved visning av tom dato på avslåtte perioder

### DIFF
--- a/content/templates/innvilget-foreldrepenger/avslag_nb.hbs
+++ b/content/templates/innvilget-foreldrepenger/avslag_nb.hbs
@@ -107,7 +107,7 @@ Du har ikke rett til foreldrepenger fra og med {{periodeFom}} til og med {{perio
 Du har ikke rett til foreldrepenger fra og med {{periodeFom}} til og med {{periodeTom}} fordi mor ikke mottar uføretrygd.
 {{/case}}
 {{#case "4007"}}
-Du kan ikke overta kvoten til den andre forelderen fra og med {{periodeFom}} til og med {{periodeFom}}.
+Du kan ikke overta kvoten til den andre forelderen fra og med {{periodeFom}} til og med {{periodeTom}}.
 
 For at du skal kunne overta kvoten, må den andre forelderen være helt avhengig av hjelp til å ta seg av {{#gt antallBarn 1}}barna{{else}}barnet{{/gt}} på grunn av egen sykdom. Legeerklæringen viser ikke dette.
 {{/case}}
@@ -123,10 +123,10 @@ Du kan ikke overta kvoten fra og med {{periodeFom}} til og med {{periodeTom}} fo
 Du kan ikke overta kvoten fra og med {{periodeFom}} til og med {{periodeTom}} fordi du ikke har aleneomsorgen for {{#gt antallBarn 1}}barna{{else}}barnet{{/gt}}. Hvis dette endrer seg kan du søke på nytt.
 {{/case}}
 {{#case "4076"}}
-Du kan ikke overta kvoten til den andre forelderen fra og med {{periodeFom}} til og med {{periodeFom}} fordi {{#if gjelderMor}}han{{else}}hun{{/if}} har rett til foreldrepenger. Hvis dette endrer seg kan du søke på nytt.
+Du kan ikke overta kvoten til den andre forelderen fra og med {{periodeFom}} til og med {{periodeTom}} fordi {{#if gjelderMor}}han{{else}}hun{{/if}} har rett til foreldrepenger. Hvis dette endrer seg kan du søke på nytt.
 {{/case}}
 {{#case "4002"}}
-Du har ikke rett til foreldrepenger fra og med {{periodeFom}} til og med {{periodeFom}} fordi det ikke er flere dager igjen av foreldrepengeperioden.
+Du har ikke rett til foreldrepenger fra og med {{periodeFom}} til og med {{periodeTom}} fordi det ikke er flere dager igjen av foreldrepengeperioden.
 {{/case}}
 {{~#case "4061"}}
 {{~>innvilget-foreldrepenger/avslag/manglende_dokumentasjon_utsette_nb~}}

--- a/src/test/resources/expected/innvilget-foreldrepenger/avslag/innvilget-foreldrepenger_førstegangsbehandling_avslag_nb.txt
+++ b/src/test/resources/expected/innvilget-foreldrepenger/avslag/innvilget-foreldrepenger_førstegangsbehandling_avslag_nb.txt
@@ -1487,7 +1487,7 @@ Du har ikke rett til foreldrepenger fra og med 26. november 2021 til og med 17. 
 
 
 
-Du kan ikke overta kvoten til den andre forelderen fra og med 26. november 2021 til og med 26. november 2021.
+Du kan ikke overta kvoten til den andre forelderen fra og med 26. november 2021 til og med 17. januar 2022.
 
 For at du skal kunne overta kvoten, må den andre forelderen være helt avhengig av hjelp til å ta seg av barnet på grunn av egen sykdom. Legeerklæringen viser ikke dette.
 
@@ -1695,7 +1695,7 @@ Du kan ikke overta kvoten fra og med 26. november 2021 til og med 17. januar 202
 
 
 
-Du kan ikke overta kvoten til den andre forelderen fra og med 26. november 2021 til og med 26. november 2021 fordi han har rett til foreldrepenger. Hvis dette endrer seg kan du søke på nytt.
+Du kan ikke overta kvoten til den andre forelderen fra og med 26. november 2021 til og med 17. januar 2022 fordi han har rett til foreldrepenger. Hvis dette endrer seg kan du søke på nytt.
 
 
 
@@ -1746,7 +1746,7 @@ Du kan ikke overta kvoten til den andre forelderen fra og med 26. november 2021 
 
 
 
-Du har ikke rett til foreldrepenger fra og med 26. november 2021 til og med 26. november 2021 fordi det ikke er flere dager igjen av foreldrepengeperioden.
+Du har ikke rett til foreldrepenger fra og med 26. november 2021 til og med 17. januar 2022 fordi det ikke er flere dager igjen av foreldrepengeperioden.
 
 
 

--- a/src/test/resources/expected/innvilget-foreldrepenger/innvilget-foreldrepenger_template_forstegangsbehandling_med_avslag_nb.txt
+++ b/src/test/resources/expected/innvilget-foreldrepenger/innvilget-foreldrepenger_template_forstegangsbehandling_med_avslag_nb.txt
@@ -532,7 +532,7 @@ Du jobber hos flere arbeidsgivere i samme periode. Det er kun mulig å kombinere
 
 
 
-Du har ikke rett til foreldrepenger fra og med 06. desember 2021 til og med 06. desember 2021 fordi det ikke er flere dager igjen av foreldrepengeperioden.
+Du har ikke rett til foreldrepenger fra og med 06. desember 2021 til og med 07. desember 2021 fordi det ikke er flere dager igjen av foreldrepengeperioden.
 
 
 


### PR DESCRIPTION
Rettet at fra og med dato ble vist som til og med dato for flere avslåtte perioder på mal innvilget-foreldrepenger og undermal avslag.