### PR TITLE
TFP-4537 Endret if statement i innvilget-foreldrepenger.

### DIFF
--- a/content/templates/innvilget-foreldrepenger/template_nb.hbs
+++ b/content/templates/innvilget-foreldrepenger/template_nb.hbs
@@ -1,7 +1,7 @@
 {{> header }}
 <br/>
 <br/>
-{{#if (and  (eq behandlingType "FØRSTEGANGSSØKNAD")(eq behandlingResultatType "INNVILGET"))}}
+{{#if (eq behandlingResultatType "INNVILGET")}}
 # NAV har innvilget søknaden din om {{dekningsgrad}} prosent foreldrepenger
 {{else if (and (eq behandlingResultatType "FORELDREPENGER_ENDRET") (eq konsekvensForInnvilgetYtelse "ENDRING_I_BEREGNING"))}}
 # NAV har beregnet foreldrepengene dine på nytt


### PR DESCRIPTION
Endret logikk for overskriften slik at tekst "NAV har innvilget søknaden din om {{dekningsgrad}} prosent foreldrepenger" kommer med når behandlingsresultattype er INNVILGET.