### PR TITLE
TFP-4582 Innvilget-foreldrepenger rettelse

### DIFF
--- a/content/templates/innvilget-foreldrepenger/dodt_barn_nb.hbs
+++ b/content/templates/innvilget-foreldrepenger/dodt_barn_nb.hbs
@@ -1,8 +1,9 @@
 
 Vi har fått melding om at {{#gt antallBarn 1}}barna dine{{else}}barnet ditt{{/gt}} døde {{dødsdato}}.
 
+{{~#if stønadsperiodeFom stønadsperiodeTom}}
 Vi sender dette brevet for å informere om at vi har innvilget deg foreldrepenger fra og med {{stønadsperiodeFom}} til og med {{stønadsperiodeTom}}.
-
+{{/if}}
 {{~#eq dekningsgrad 80}}
 Vi har gjort om søknaden din fra 80 prosent til 100 prosent foreldrepenger.
 {{/eq}}

--- a/content/templates/innvilget-foreldrepenger/innvilget_nb.hbs
+++ b/content/templates/innvilget-foreldrepenger/innvilget_nb.hbs
@@ -114,7 +114,8 @@ I samme periode tar du ut 100 prosent permisjon hos {{this.arbeidsgiverNavn}}.
 
 {{#if (and (gt antallInnvilgedePerioder 0) (eq konsekvensForInnvilgetYtelse "ENDRING_I_UTTAK"))}}
 Foreldrepengene utgjør det samme som tidligere. Sjekk utbetalingene dine på [nav.no/utbetalinger](https://nav.no/utbetalinger).
+{{#if stønadsperiodeTom}}
 {{#eq dagerTaptFørTermin 0}}
 Den siste dagen med foreldrepenger er {{stønadsperiodeTom}}.
-{{/eq}}
+{{/eq}}{{/if}}
 {{/if}}

--- a/content/templates/innvilget-foreldrepenger/schema.json
+++ b/content/templates/innvilget-foreldrepenger/schema.json
@@ -34,7 +34,6 @@
     "antallArbeidsgivere",
     "dagerTaptFørTermin",
     "disponibleDager",
-    "sisteDagAvSistePeriode",
     "antallBarn",
     "antallDødeBarn",
     "perioder",

--- a/content/templates/innvilget-foreldrepenger/template_nb.hbs
+++ b/content/templates/innvilget-foreldrepenger/template_nb.hbs
@@ -30,7 +30,7 @@ Du får {{format-kroner dagsats}} kroner per dag før skatt. Dette er i gjennoms
 
 {{#if inkludereUtbetNårGradering}}{{> innvilget-foreldrepenger/utbetaling_nb}}{{/if}}
 
-{{~#neq sisteDagAvSistePeriode ""}}
+{{~#if sisteDagAvSistePeriode}}
 {{#gt disponibleDager 0}}
 {{~#if (or (eq annenForelderHarRett false) (eq aleneomsorgKode "JA"))}}
 Det er {{disponibleDager}} {{#gt disponibleDager 1}}dager{{else}}dag{{/gt}} igjen av perioden med foreldrepenger. {{#gt disponibleDager 1}}Disse dagene{{else}}Denne dagen{{/gt}} må du søke om innen {{sisteDagAvSistePeriode}}.{{/if}}{{/gt}}
@@ -38,7 +38,7 @@ Det er {{disponibleDager}} {{#gt disponibleDager 1}}dager{{else}}dag{{/gt}} igje
 {{~#if (and (eq annenForelderHarRett true) (neq aleneomsorgKode "JA"))}}
 Det er {{disponibleDager}} {{#eq disponibleDager 1}}dag{{else}}dager{{/eq}} igjen av kvoten din, og {{disponibleFellesDager}} {{#eq disponibleFellesDager 1}}dag{{else}}dager{{/eq}} som dere begge kan ta ut.
 {{~#eq disponibleDager 1}}{{#if (or (eq disponibleFellesDager 0)(eq disponibleFellesDager 1))}} Denne dagen{{/if}}{{/eq}}{{#if (or (gt disponibleFellesDager 1)(gt disponibleDager 1))}} Disse dagene{{/if}} må det søkes om innen {{sisteDagAvSistePeriode}}.
-{{/if}}{{/if}}{{/neq}}
+{{/if}}{{/if}}{{/if}}
 
 {{~#gt antallArbeidsgivere 1}}
 {{~#each perioder}}{{#if @first}}{{~#each arbeidsforholdsliste}}{{~#if this.gradering }}
@@ -52,8 +52,9 @@ Du jobber hos flere arbeidsgivere i samme periode. Det er kun mulig å kombinere
 {{#if (and (eq barnErFødt true) (eq gjelderMor true) (eq årsakErFødselshendelse true))}}
 {{#gt dagerTaptFørTermin 0}}
 {{#if (or (eq konsekvensForInnvilgetYtelse "ENDRING_I_UTTAK") (eq konsekvensForInnvilgetYtelse "ENDRING_I_BEREGNING_OG_UTTAK"))}}
+{{#if stønadsperiodeTom }}
 Vi har endret den siste dagen din med foreldrepenger til {{stønadsperiodeTom}}.
-
+{{/if}}
 Perioden med foreldrepenger starter tre uker før termin. Du fødte før termin, og derfor mister du {{dagerTaptFørTermin}} {{#gt dagerTaptFørTermin 1}}dager{{else}}dag{{/gt}} med foreldrepenger.
 {{/if}}
 {{/gt}}

--- a/content/templates/innvilget-foreldrepenger/utbetaling_nb.hbs
+++ b/content/templates/innvilget-foreldrepenger/utbetaling_nb.hbs
@@ -1,6 +1,7 @@
-{{#if (and (neq stønadsperiodeFom "") (gt dagsats 0))}}
+{{#if stønadsperiodeFom stønadsperiodeTom}}
+{{#gt dagsats 0}}
 Du får {{format-kroner dagsats}} kroner per dag før skatt fra og med {{stønadsperiodeFom}}. Dette er i gjennomsnitt {{format-kroner månedsbeløp}} kroner i måneden. Den siste dagen du får foreldrepenger er {{stønadsperiodeTom}}.
-{{/if}}
+{{/gt}}{{/if}}
 
 {{> innvilget-foreldrepenger/felles/refusjon_nb }}
 


### PR DESCRIPTION
Fjernet at sisteDagAvSistePeriode var required da den kan være null i visse tilfeller. Feks ved avslag på alle utbetalingsperioder.