### PR TITLE
TFP-4601 Fix innvilgelse foreldrepenger

### DIFF
--- a/content/templates/innvilget-foreldrepenger/beregning_nb.hbs
+++ b/content/templates/innvilget-foreldrepenger/beregning_nb.hbs
@@ -2,7 +2,10 @@
 
 **Inntekt vi har brukt i beregningen**<br/>
 
-{{#eq harBruktBruttoBeregningsgrunnlag true}}
+{{~#if felles.fritekst}}
+{{felles.fritekst}}
+{{else}}
+{{~#eq harBruktBruttoBeregningsgrunnlag true}}
 Vi har brukt {{format-kroner bruttoBeregningsgrunnlag}} kroner i året før skatt i beregningen av foreldrepengene dine.
 {{/eq}}
 
@@ -118,4 +121,4 @@ Vi har fastsatt foreldrepengene dine til tre ganger grunnbeløpet fordi du har v
 Vi har beregnet foreldrepengene dine ut fra en inntekt på {{format-kroner (divide 12 bruttoBeregningsgrunnlag)}} kroner i måneden før skatt. Dette er gjennomsnittet av inntekten du har fått fra NAV de siste tre månedene.
 {{/eq}}
 {{/each}}
-{{/if}}
+{{/if}}{{/if}}

--- a/content/templates/innvilget-foreldrepenger/dodt_barn_nb.hbs
+++ b/content/templates/innvilget-foreldrepenger/dodt_barn_nb.hbs
@@ -17,13 +17,10 @@ Du får {{format-kroner dagsats}} kroner per dag før skatt. Dette er i gjennoms
 {{/if}}
 
 {{~#neq konsekvensForInnvilgetYtelse "ENDRING_I_UTTAK"}}
-{{#if felles.fritekst}}
-<br/>
-
-**Inntekt vi har brukt i beregningen**<br/>
-{{felles.fritekst}}
-{{else}}
 {{> innvilget-foreldrepenger/beregning_nb}}
+{{else}}
+{{#if felles.fritekst}}
+{{felles.fritekst}}
 {{/if}}
 {{/neq}}
 

--- a/content/templates/innvilget-foreldrepenger/template_nb.hbs
+++ b/content/templates/innvilget-foreldrepenger/template_nb.hbs
@@ -65,13 +65,10 @@ Perioden med foreldrepenger starter tre uker før termin. Du fødte før termin,
 {{/if}}
 
 {{~#neq konsekvensForInnvilgetYtelse "ENDRING_I_UTTAK"}}
-{{#if felles.fritekst}}
-<br/>
-
-**Inntekt vi har brukt i beregningen**<br/>
-{{felles.fritekst}}
-{{else}}
 {{> innvilget-foreldrepenger/beregning_nb}}
+{{else}}
+{{#if felles.fritekst}}
+{{felles.fritekst}}
 {{/if}}
 {{/neq}}
 

--- a/content/templates/innvilget-foreldrepenger/testdata/revurdering/foreldrepenger_endret_endring_i_uttak.json
+++ b/content/templates/innvilget-foreldrepenger/testdata/revurdering/foreldrepenger_endret_endring_i_uttak.json
@@ -7,6 +7,7 @@
     "erKopi": false,
     "harVerge": false,
     "saksnummer": "141081123",
+    "fritekst": "Tester at fritekst kommer etter vedtakshjemler når endring i uttak",
     "ytelseType": "FP",
     "behandlesAvKA": false
   },

--- a/src/test/resources/expected/innvilget-foreldrepenger/revurdering/foreldrepenger_endret_nb.txt
+++ b/src/test/resources/expected/innvilget-foreldrepenger/revurdering/foreldrepenger_endret_nb.txt
@@ -307,7 +307,7 @@ Vedtaket er gjort etter folketrygdloven §§ 14-9, 14-10 og 14-12.
 
 
 
-
+Tester at fritekst kommer etter vedtakshjemler når endring i uttak
 
 
 


### PR DESCRIPTION
Rettet at fritekst blir skrevet ut om det er endring i uttak og det eksisterer fritekst. Samme rettelse for dødt_barn mal