### PR TITLE
TFP-4583 Fix innvilgelse foreldrepenger

### DIFF
--- a/content/templates/innvilget-foreldrepenger/innvilget_nb.hbs
+++ b/content/templates/innvilget-foreldrepenger/innvilget_nb.hbs
@@ -68,7 +68,7 @@ Vi har redusert utbetalingen din fordi du jobber i denne perioden. Selv om du jo
 
 
 {{#if (and (eq arbeidsforholdsliste.0.gradering true) (eq innvilget true))}}
-{{>punkt}}Du tar ut {{trim-decimal arbeidsforholdsliste.0.utbetalingsgrad}} prosent foreldrepenger fra og med {{periodeFom}} til og med {{periodeTom}} fordi du jobber {{trim-decimal arbeidsforholdsliste.0.stillingsprosent}} prosent hos {{arbeidsforholdsliste.0.arbeidsgiverNavn}}. I denne perioden får du {{format-kroner periodeDagsats}} kroner per dag før skatt.
+{{>punkt}}Du tar ut {{trim-decimal arbeidsforholdsliste.0.utbetalingsgrad}} prosent foreldrepenger fra og med {{periodeFom}} til og med {{periodeTom}} fordi du jobber {{trim-decimal arbeidsforholdsliste.0.prosentArbeid}} prosent hos {{arbeidsforholdsliste.0.arbeidsgiverNavn}}. I denne perioden får du {{format-kroner periodeDagsats}} kroner per dag før skatt.
 {{#each arbeidsforholdsliste}}
 {{#if (and (eq this.prosentArbeid this.stillingsprosent) (lt this.stillingsprosent 100.0))}} {{#if (and (eq this.gradering false) (eq arbeidsforholdsliste.0.gradering true))}}
 Selv om du er tilbake i arbeid hos {{this.arbeidsgiverNavn}} har du fremdeles rett til foreldrepenger. Derfor får du fremdeles utbetalt foreldrepenger.

--- a/src/test/resources/expected/innvilget-foreldrepenger/forstegangsbehandling/forstegangsbehandling_gradering_nb.txt
+++ b/src/test/resources/expected/innvilget-foreldrepenger/forstegangsbehandling/forstegangsbehandling_gradering_nb.txt
@@ -62,7 +62,7 @@ Fødselsnummer: 300220 12345
 
 
 
-Du tar ut 50 prosent foreldrepenger fra og med 19. mai 2021 til og med 14. desember 2021 fordi du jobber 100 prosent hos TULLE TRANSPORT AS. I denne perioden får du 1 356 kroner per dag før skatt.
+Du tar ut 50 prosent foreldrepenger fra og med 19. mai 2021 til og med 14. desember 2021 fordi du jobber 50 prosent hos TULLE TRANSPORT AS. I denne perioden får du 1 356 kroner per dag før skatt.
 
 
   


### PR DESCRIPTION
Rettet at arbeidstidsprosent ble brukt i stedet for stillingsprosent i teksten "Du tar ut ... prosent foreldrepenger fra og med .. til og med .. fordi du jobber ... prosent hos..."