### PR TITLE
TFP-4552 Rettelse forldrepenger avslag

### DIFF
--- a/content/templates/foreldrepenger-avslag/template_en.hbs
+++ b/content/templates/foreldrepenger-avslag/template_en.hbs
@@ -22,7 +22,7 @@
 
 
 {{#eq avslagsårsak "1041"}}
-{{>punkt}}You are not entitled to parental benefit, because your income is lower than {{halvG}} kroner per year before tax.
+{{>punkt}}You are not entitled to parental benefit, because your income is lower than {{format-kroner halvG}} kroner per year before tax.
 {{/eq}}
 
 

--- a/content/templates/foreldrepenger-avslag/template_nb.hbs
+++ b/content/templates/foreldrepenger-avslag/template_nb.hbs
@@ -22,7 +22,7 @@
 
 
 {{#eq avslagsårsak "1041"}}
-{{>punkt}}Du har ikke rett til foreldrepenger, fordi inntekten din er lavere enn {{halvG}} kroner i året før skatt.
+{{>punkt}}Du har ikke rett til foreldrepenger, fordi inntekten din er lavere enn {{format-kroner halvG}} kroner i året før skatt.
 {{/eq}}
 
 

--- a/content/templates/foreldrepenger-avslag/template_nn.hbs
+++ b/content/templates/foreldrepenger-avslag/template_nn.hbs
@@ -22,7 +22,7 @@
 
 
 {{#eq avslagsårsak "1041"}}
-{{>punkt}}Du har ikkje rett til foreldrepengar fordi inntekta di er lågare enn {{halvG}} kroner i året før skatt.
+{{>punkt}}Du har ikkje rett til foreldrepengar fordi inntekta di er lågare enn {{format-kroner halvG}} kroner i året før skatt.
 {{/eq}}
 
 

--- a/src/test/resources/expected/foreldrepenger-avslag/foreldrepenger-avslag_mange_en.txt
+++ b/src/test/resources/expected/foreldrepenger-avslag/foreldrepenger-avslag_mange_en.txt
@@ -20,7 +20,7 @@ National identity number: 300220 12345
 
 * You are not entitled to parental benefit, because you have not had earned income or income equivalent to earned income in six of the past ten months before the start of the parental benefit period.
 
-* You are not entitled to parental benefit, because your income is lower than 50000 kroner per year before tax.
+* You are not entitled to parental benefit, because your income is lower than 50 000 kroner per year before tax.
 
 * You are not entitled to parental benefit, because you have applied too early. You can apply when you are in your 22nd week of pregnancy.
 

--- a/src/test/resources/expected/foreldrepenger-avslag/foreldrepenger-avslag_mange_nb.txt
+++ b/src/test/resources/expected/foreldrepenger-avslag/foreldrepenger-avslag_mange_nb.txt
@@ -20,7 +20,7 @@ Fødselsnummer: 300220 12345
 
 * Du har ikke rett til foreldrepenger, fordi du ikke har hatt arbeidsinntekt eller inntekt som er likestilt med lønn i seks av de siste ti månedene før foreldrepengeperioden starter.
 
-* Du har ikke rett til foreldrepenger, fordi inntekten din er lavere enn 50000 kroner i året før skatt.
+* Du har ikke rett til foreldrepenger, fordi inntekten din er lavere enn 50 000 kroner i året før skatt.
 
 * Du har ikke rett til foreldrepenger fordi du har søkt for tidlig. Du kan søke når du er i svangerskapsuke 22.
 

--- a/src/test/resources/expected/foreldrepenger-avslag/foreldrepenger-avslag_mange_nn.txt
+++ b/src/test/resources/expected/foreldrepenger-avslag/foreldrepenger-avslag_mange_nn.txt
@@ -20,7 +20,7 @@ Fødselsnummer: 300220 12345
 
 * Du har ikkje rett til foreldrepengar fordi du ikkje har hatt arbeidsinntekt eller inntekt som er likestilt med lønn i seks av dei siste ti månadene før foreldrepengeperioden startar.
 
-* Du har ikkje rett til foreldrepengar fordi inntekta di er lågare enn 50000 kroner i året før skatt.
+* Du har ikkje rett til foreldrepengar fordi inntekta di er lågare enn 50 000 kroner i året før skatt.
 
 * Du har ikkje rett til foreldrepengar fordi du har søkt for tidleg. Du kan tidlegast søkje når du er i svangerskapsveke 22.
 


### PR DESCRIPTION
Rettet at inntektsbeløpet var formatert med tusen skilletegn når avslagsgrunn er 1041