### PR TITLE
TFP-4622 Endring innv./avslag foreldrepenger

### DIFF
--- a/content/templates/foreldrepenger-avslag/schema.json
+++ b/content/templates/foreldrepenger-avslag/schema.json
@@ -9,7 +9,8 @@
     "klagefristUker",
     "lovhjemmelForAvslag",
     "antallPerioder",
-    "avslåttePerioder"
+    "avslåttePerioder",
+    "kreverSammenhengendeUttak"
   ],
   "$defs": {
     "avslåttPeriode": {
@@ -66,6 +67,9 @@
     },
     "antallPerioder": {
       "type": "number"
+    },
+    "kreverSammenhengendeUttak": {
+      "type": "boolean"
     },
     "avslåttePerioder": {
       "type": "array",

--- a/content/templates/foreldrepenger-avslag/template_en.hbs
+++ b/content/templates/foreldrepenger-avslag/template_en.hbs
@@ -271,12 +271,16 @@
 {{>indent}}Your parental benefit may only be combined with work six weeks after birth.
 {{/eq}}
 
-
 {{#eq avslagsårsak "4025"}}
+{{#if kreverSammenhengendeUttak }}
 {{>punkt}}You cannot combine parental benefit with work from {{periodeFom}} up to and including {{periodeTom}}.
 
 {{>indent}}Because you work in a full time position or more, you cannot take out parental benefit at the same time, but you may postpone the period.
-{{/eq}}
+{{else}}
+{{>punkt}}You cannot combine parental benefit with work from {{periodeFom}} up to and including {{periodeTom}}.
+
+{{>indent}}Because you work in a full time position or more, you cannot take out parental benefit at the same time.
+{{/if}}{{/eq}}
 
 
 {{#in-array (array "4080" "4501") avslagsårsak}}

--- a/content/templates/foreldrepenger-avslag/template_nb.hbs
+++ b/content/templates/foreldrepenger-avslag/template_nb.hbs
@@ -273,13 +273,16 @@
 {{>indent}}Foreldrepengene dine kan først kombineres med arbeid seks uker etter fødselen.
 {{/eq}}
 
-
 {{#eq avslagsårsak "4025"}}
+{{#if kreverSammenhengendeUttak }}
 {{>punkt}}Du kan ikke kombinere foreldrepengene med arbeid fra og med {{periodeFom}} til og med {{periodeTom}}.
 
 {{>indent}}Fordi du jobber 100 prosent eller mer kan du ikke ta ut foreldrepenger ved siden av arbeidet, men du kan utsette perioden.
-{{/eq}}
+{{else}}
+{{>punkt}}Du kan ikke kombinere foreldrepengene med arbeid fra og med {{periodeFom}} til og med {{periodeTom}}.
 
+{{>indent}}Fordi du jobber 100 prosent eller mer kan du ikke ta ut foreldrepenger ved siden av arbeidet.
+{{/if}}{{/eq}}
 
 {{#in-array (array "4080" "4501") avslagsårsak}}
 {{>punkt}}Du kan ikke kombinere foreldrepengene med arbeid fra og med {{periodeFom}} til og med {{periodeTom}} fordi du har søkt for sent.

--- a/content/templates/foreldrepenger-avslag/template_nn.hbs
+++ b/content/templates/foreldrepenger-avslag/template_nn.hbs
@@ -271,13 +271,16 @@
 {{>indent}}Foreldrepengane dine kan først kombinerast med arbeid seks veker etter fødselen.
 {{/eq}}
 
-
 {{#eq avslagsårsak "4025"}}
+{{#if kreverSammenhengendeUttak }}
 {{>punkt}}Du kan ikkje kombinere foreldrepengane med arbeid frå og med {{periodeFom}} til og med {{periodeTom}}.
 
 {{>indent}}Fordi du jobbar 100 prosent eller meir, kan du ikkje ta ut foreldrepengar ved sida av arbeidet, men du kan utsetje perioden.
-{{/eq}}
+{{else}}
+{{>punkt}}Du kan ikkje kombinere foreldrepengane med arbeid frå og med {{periodeFom}} til og med {{periodeTom}}.
 
+{{>indent}}Fordi du jobbar 100 prosent eller meir, kan du ikkje ta ut foreldrepengar ved sida av arbeidet.
+{{/if}}{{/eq}}
 
 {{#in-array (array "4080" "4501") avslagsårsak}}
 {{>punkt}}Du kan ikkje kombinere foreldrepengane med arbeid frå og med {{periodeFom}} til og med {{periodeTom}} fordi du har søkt for seint.

--- a/content/templates/foreldrepenger-avslag/testdata/test_fritekst.json
+++ b/content/templates/foreldrepenger-avslag/testdata/test_fritekst.json
@@ -19,6 +19,7 @@
   "klagefristUker": 6,
   "lovhjemmelForAvslag": "§ forvaltningsloven § 35",
   "antallPerioder": 1,
+  "kreverSammenhengendeUttak": true,
   "avslåttePerioder": [
     {
       "avslagsårsak": "1035",

--- a/content/templates/foreldrepenger-avslag/testdata/test_mange.json
+++ b/content/templates/foreldrepenger-avslag/testdata/test_mange.json
@@ -18,6 +18,7 @@
   "klagefristUker": 6,
   "lovhjemmelForAvslag": "§ forvaltningsloven § 35",
   "antallPerioder": 81,
+  "kreverSammenhengendeUttak": true,
   "avslåttePerioder": [
     {
       "avslagsårsak": "1035",

--- a/content/templates/innvilget-foreldrepenger/avslag_nb.hbs
+++ b/content/templates/innvilget-foreldrepenger/avslag_nb.hbs
@@ -81,9 +81,15 @@
 {{>indent}}For å ha rett til å utsette foreldrepengene må du søke før du begynner å jobbe.
 {{/case}}
 {{#case "4025"}}
+{{#if kreverSammenhengendeUttak }}
 {{>punkt}}Du kan ikke kombinere foreldrepengene med arbeid fra og med {{periodeFom}} til og med {{periodeTom}}.
 
 {{>indent}}Fordi du jobber 100 prosent eller mer kan du ikke ta ut foreldrepenger ved siden av arbeidet, men du kan utsette perioden.
+{{else}}
+{{>punkt}}Du kan ikke kombinere foreldrepengene med arbeid fra og med {{periodeFom}} til og med {{periodeTom}}.
+
+{{>indent}}Fordi du jobber 100 prosent eller mer kan du ikke ta ut foreldrepenger ved siden av arbeidet.
+{{/if}}
 {{/case}}
 {{#case "4093"}}
 {{>punkt}}Du kan ikke kombinere foreldrepengene med arbeid fra og med {{periodeFom}} til og med {{periodeTom}} fordi du ikke er i jobb.

--- a/content/templates/innvilget-foreldrepenger/schema.json
+++ b/content/templates/innvilget-foreldrepenger/schema.json
@@ -36,6 +36,7 @@
     "disponibleDager",
     "antallBarn",
     "antallDødeBarn",
+    "kreverSammenhengendeUttak",
     "perioder",
     "bruttoBeregningsgrunnlag",
     "harBruktBruttoBeregningsgrunnlag",
@@ -360,6 +361,9 @@
     },
     "bruttoBeregningsgrunnlag": {
       "type": "number"
+    },
+    "kreverSammenhengendeUttak": {
+      "type": "boolean"
     },
     "perioder": {
       "type": "array",

--- a/content/templates/innvilget-foreldrepenger/testdata/avslag/førstegangsbehandling_avslag.json
+++ b/content/templates/innvilget-foreldrepenger/testdata/avslag/førstegangsbehandling_avslag.json
@@ -46,6 +46,7 @@
   "antallBarn": 1,
   "prematurDager": 0,
   "antallDødeBarn": 0,
+  "kreverSammenhengendeUttak": true,
   "perioder": [
     {
       "innvilget": true,

--- a/content/templates/innvilget-foreldrepenger/testdata/beregning/førstegangsbehandling_en_ag.json
+++ b/content/templates/innvilget-foreldrepenger/testdata/beregning/førstegangsbehandling_en_ag.json
@@ -46,6 +46,7 @@
   "antallBarn": 2,
   "prematurDager": 1,
   "antallDødeBarn": 0,
+  "kreverSammenhengendeUttak": true,
   "perioder": [
     {
       "innvilget": true,

--- a/content/templates/innvilget-foreldrepenger/testdata/beregning/førstegangsbehandling_frilans.json
+++ b/content/templates/innvilget-foreldrepenger/testdata/beregning/førstegangsbehandling_frilans.json
@@ -46,6 +46,7 @@
   "antallBarn": 2,
   "prematurDager": 1,
   "antallDødeBarn": 0,
+  "kreverSammenhengendeUttak": true,
   "perioder": [
     {
       "innvilget": true,

--- a/content/templates/innvilget-foreldrepenger/testdata/beregning/førstegangsbehandling_næring.json
+++ b/content/templates/innvilget-foreldrepenger/testdata/beregning/førstegangsbehandling_næring.json
@@ -47,6 +47,7 @@
   "antallBarn": 1,
   "prematurDager": 0,
   "antallDødeBarn": 0,
+  "kreverSammenhengendeUttak": true,
   "perioder": [
     {
       "innvilget": true,

--- a/content/templates/innvilget-foreldrepenger/testdata/beregning/førstegangsbehandling_to_ag.json
+++ b/content/templates/innvilget-foreldrepenger/testdata/beregning/førstegangsbehandling_to_ag.json
@@ -46,6 +46,7 @@
   "antallBarn": 2,
   "prematurDager": 1,
   "antallDødeBarn": 0,
+  "kreverSammenhengendeUttak": true,
   "perioder": [
     {
       "innvilget": true,

--- a/content/templates/innvilget-foreldrepenger/testdata/beregning/revurdering_kun_ytelse_80_dg.json
+++ b/content/templates/innvilget-foreldrepenger/testdata/beregning/revurdering_kun_ytelse_80_dg.json
@@ -48,6 +48,7 @@
   "antallBarn": 1,
   "prematurDager": 0,
   "antallDødeBarn": 0,
+  "kreverSammenhengendeUttak": true,
   "perioder": [
     {
       "innvilget": true,

--- a/content/templates/innvilget-foreldrepenger/testdata/dodt_barn/dodt_barn_forstegangsbehandling.json
+++ b/content/templates/innvilget-foreldrepenger/testdata/dodt_barn/dodt_barn_forstegangsbehandling.json
@@ -49,6 +49,7 @@
   "antallBarn": 1,
   "prematurDager": 0,
   "antallDødeBarn": 1,
+  "kreverSammenhengendeUttak": true,
   "dødsdato":"15. august 2021",
   "perioder": [
     {

--- a/content/templates/innvilget-foreldrepenger/testdata/forstegangsbehandling/automatisk_ingen_gradering_ingen_avslag.json
+++ b/content/templates/innvilget-foreldrepenger/testdata/forstegangsbehandling/automatisk_ingen_gradering_ingen_avslag.json
@@ -46,6 +46,7 @@
   "foreldrepengeperiodenUtvidetUker": 0,
   "antallBarn": 1,
   "antallDødeBarn": 0,
+  "kreverSammenhengendeUttak": true,
   "prematurDager": 0,
   "perioder": [
     {

--- a/content/templates/innvilget-foreldrepenger/testdata/forstegangsbehandling/gradering_flere_arbgivere_og_gradering.json
+++ b/content/templates/innvilget-foreldrepenger/testdata/forstegangsbehandling/gradering_flere_arbgivere_og_gradering.json
@@ -50,6 +50,7 @@
   "antallBarn": 1,
   "prematurDager": 0,
   "antallDødeBarn": 0,
+  "kreverSammenhengendeUttak": true,
   "perioder": [
     {
       "innvilget": true,

--- a/content/templates/innvilget-foreldrepenger/testdata/forstegangsbehandling/med_avslag_periode.json
+++ b/content/templates/innvilget-foreldrepenger/testdata/forstegangsbehandling/med_avslag_periode.json
@@ -47,6 +47,7 @@
   "antallBarn": 2,
   "prematurDager": 0,
   "antallDødeBarn": 0,
+  "kreverSammenhengendeUttak": true,
   "perioder": [
     {
       "innvilget": true,

--- a/content/templates/innvilget-foreldrepenger/testdata/forstegangsbehandling/med_fritekst.json
+++ b/content/templates/innvilget-foreldrepenger/testdata/forstegangsbehandling/med_fritekst.json
@@ -51,6 +51,7 @@
   "antallBarn": 1,
   "prematurDager": 0,
   "antallDødeBarn": 0,
+  "kreverSammenhengendeUttak": true,
   "perioder": [
     {
       "innvilget": true,

--- a/content/templates/innvilget-foreldrepenger/testdata/innvilget/førstegangsbehandling_annenaktivitet_næring.json
+++ b/content/templates/innvilget-foreldrepenger/testdata/innvilget/førstegangsbehandling_annenaktivitet_næring.json
@@ -46,6 +46,7 @@
   "antallBarn": 2,
   "prematurDager": 1,
   "antallDødeBarn": 0,
+  "kreverSammenhengendeUttak": true,
   "perioder": [
     {
       "innvilget": true,

--- a/content/templates/innvilget-foreldrepenger/testdata/innvilget/førstegangsbehandling_arbeidsforhold.json
+++ b/content/templates/innvilget-foreldrepenger/testdata/innvilget/førstegangsbehandling_arbeidsforhold.json
@@ -46,6 +46,7 @@
   "antallBarn": 2,
   "prematurDager": 1,
   "antallDødeBarn": 0,
+  "kreverSammenhengendeUttak": true,
   "perioder": [
     {
       "innvilget": true,

--- a/content/templates/innvilget-foreldrepenger/testdata/innvilget/førstegangsbehandling_enkeltårsaker.json
+++ b/content/templates/innvilget-foreldrepenger/testdata/innvilget/førstegangsbehandling_enkeltårsaker.json
@@ -46,6 +46,7 @@
   "antallBarn": 2,
   "prematurDager": 1,
   "antallDødeBarn": 0,
+  "kreverSammenhengendeUttak": true,
   "perioder": [
     {
       "innvilget": true,

--- a/content/templates/innvilget-foreldrepenger/testdata/innvilget/førstegangsbehandling_fullt.json
+++ b/content/templates/innvilget-foreldrepenger/testdata/innvilget/førstegangsbehandling_fullt.json
@@ -46,6 +46,7 @@
   "antallBarn": 2,
   "prematurDager": 1,
   "antallDødeBarn": 0,
+  "kreverSammenhengendeUttak": true,
   "perioder": [
     {
       "innvilget": true,

--- a/content/templates/innvilget-foreldrepenger/testdata/innvilget/førstegangsbehandling_innvilget_og_avslått.json
+++ b/content/templates/innvilget-foreldrepenger/testdata/innvilget/førstegangsbehandling_innvilget_og_avslått.json
@@ -46,6 +46,7 @@
   "antallBarn": 2,
   "prematurDager": 1,
   "antallDødeBarn": 0,
+  "kreverSammenhengendeUttak": true,
   "perioder": [
     {
       "innvilget": true,

--- a/content/templates/innvilget-foreldrepenger/testdata/innvilget/førstegangsbehandling_prosent.json
+++ b/content/templates/innvilget-foreldrepenger/testdata/innvilget/førstegangsbehandling_prosent.json
@@ -46,6 +46,7 @@
   "antallBarn": 2,
   "prematurDager": 1,
   "antallDødeBarn": 0,
+  "kreverSammenhengendeUttak": true,
   "perioder": [
     {
       "innvilget": true,

--- a/content/templates/innvilget-foreldrepenger/testdata/revurdering/foreldrepenger_endret_barn_dod.json
+++ b/content/templates/innvilget-foreldrepenger/testdata/revurdering/foreldrepenger_endret_barn_dod.json
@@ -45,6 +45,7 @@
   "antallBarn": 1,
   "prematurDager": 0,
   "antallDødeBarn": 1,
+  "kreverSammenhengendeUttak": true,
   "dødsdato": "15. juni 2021",
   "perioder": [
     {

--- a/content/templates/innvilget-foreldrepenger/testdata/revurdering/foreldrepenger_endret_endring_i_beregning.json
+++ b/content/templates/innvilget-foreldrepenger/testdata/revurdering/foreldrepenger_endret_endring_i_beregning.json
@@ -47,6 +47,7 @@
   "antallBarn": 1,
   "prematurDager": 0,
   "antallDødeBarn": 0,
+  "kreverSammenhengendeUttak": true,
   "perioder": [
     {
       "innvilget": true,

--- a/content/templates/innvilget-foreldrepenger/testdata/revurdering/foreldrepenger_endret_endring_i_uttak.json
+++ b/content/templates/innvilget-foreldrepenger/testdata/revurdering/foreldrepenger_endret_endring_i_uttak.json
@@ -49,6 +49,7 @@
   "antallBarn": 1,
   "prematurDager": 0,
   "antallDødeBarn": 0,
+  "kreverSammenhengendeUttak": true,
   "perioder": [
     {
       "innvilget": true,

--- a/content/templates/innvilget-foreldrepenger/testdata/revurdering/foreldrepenger_innvilget_endring_i_uttak.json
+++ b/content/templates/innvilget-foreldrepenger/testdata/revurdering/foreldrepenger_innvilget_endring_i_uttak.json
@@ -47,6 +47,7 @@
   "antallBarn": 1,
   "prematurDager": 0,
   "antallDødeBarn": 0,
+  "kreverSammenhengendeUttak": true,
   "perioder": [
     {
       "innvilget": true,

--- a/content/templates/innvilget-foreldrepenger/testdata/utbetaling/førstegangsbehandling_delvis_refusjon.json
+++ b/content/templates/innvilget-foreldrepenger/testdata/utbetaling/førstegangsbehandling_delvis_refusjon.json
@@ -47,6 +47,7 @@
   "antallBarn": 3,
   "prematurDager": 0,
   "antallDødeBarn": 0,
+  "kreverSammenhengendeUttak": true,
   "perioder": [
     {
       "innvilget": true,

--- a/content/templates/innvilget-foreldrepenger/testdata/utbetaling/førstegangsbehandling_full_refusjon.json
+++ b/content/templates/innvilget-foreldrepenger/testdata/utbetaling/førstegangsbehandling_full_refusjon.json
@@ -47,6 +47,7 @@
   "antallBarn": 2,
   "prematurDager": 1,
   "antallDødeBarn": 0,
+  "kreverSammenhengendeUttak": true,
   "perioder": [
     {
       "innvilget": true,

--- a/content/templates/innvilget-foreldrepenger/testdata/utbetaling/førstegangsbehandling_ingen_refusjon.json
+++ b/content/templates/innvilget-foreldrepenger/testdata/utbetaling/førstegangsbehandling_ingen_refusjon.json
@@ -47,6 +47,7 @@
   "antallBarn": 1,
   "prematurDager": 0,
   "antallDødeBarn": 0,
+  "kreverSammenhengendeUttak": true,
   "perioder": [
     {
       "innvilget": true,


### PR DESCRIPTION
Lagt til parameteren kreverSammenhengeUttak for innvilgelse og avslag foreldrepenger for å kunne skille på tekst som gjelder før og etter fritt uttak for samme årsak.