### PR TITLE
TFP-4414 Rettelse benefits to benefit

### DIFF
--- a/content/templates/engangsstonad-avslag/template_en.hbs
+++ b/content/templates/engangsstonad-avslag/template_en.hbs
@@ -47,7 +47,7 @@ The mother has already received the lump-sum grant and therefore, your applicati
 You have already received the lump-sum grant and therefore, your application has been turned down.
     {{/case}}
     {{#case "ALLEREDE_UTBETALT_FORELDREPENGER"}}
-You have already received the parental benefits and therefore, your application has been turned down.
+You have already received the parental benefit and therefore, your application has been turned down.
     {{/case}}
     {{#case "SØKT_FOR_SENT"}}
 You are not entitled to a lump-sum grant because you did not apply in time. You must apply within six months of the birth or when you assumed care of your {{#eq antallBarn 1}}child{{else}}children{{/eq}}.

--- a/content/templates/foreldrepenger-avslag/template_en.hbs
+++ b/content/templates/foreldrepenger-avslag/template_en.hbs
@@ -340,7 +340,7 @@
 {{#if kreverSammenhengendeUttak }}
 {{>punkt}}You cannot postpone parental benefit from {{periodeFom}} up to and including {{periodeTom}}.
 
-  You can only postpone parental benefits if the mother is working, studying or taking part in some other activity. You can read more about this at [nav.no/foreldrepenger](https://nav.no/foreldrepenger).
+  You can only postpone parental benefit if the mother is working, studying or taking part in some other activity. You can read more about this at [nav.no/foreldrepenger](https://nav.no/foreldrepenger).
 {{else}}
 {{>punkt}}You may not have a break in the period of parental benefit from {{periodeFom}} up to and including {{periodeTom}}.
 

--- a/content/templates/foreldrepenger-infotilannenforelder/template_en.hbs
+++ b/content/templates/foreldrepenger-infotilannenforelder/template_en.hbs
@@ -1,19 +1,19 @@
 {{> header }}
 
 
-# You must apply for parental benefits in time
+# You must apply for parental benefit in time
 {{>brukerdetaljer_en}}
 
 {{#eq behandlingsÅrsak "INFOBREV_BEHANDLING"}}
 {{#if kreverSammenhengendeUttak}}
 
-You may be entitled to parental benefits. You must apply before {{sisteUttaksdagMor}}. This is the day the other parent has the last day of parental benefit. If you do not want to start the parental benefit period immediately after {{sisteUttaksdagMor}}, you must apply to postpone the period. If you apply at a later date, you will lose the days you did not postpone.
+You may be entitled to parental benefit. You must apply before {{sisteUttaksdagMor}}. This is the day the other parent has the last day of parental benefit. If you do not want to start the parental benefit period immediately after {{sisteUttaksdagMor}}, you must apply to postpone the period. If you apply at a later date, you will lose the days you did not postpone.
 
 **The change of parental benefit law for children born from 1 October 2021**
 For children born from and including 1 October 2021, the parents decide when they want to take out the parental benefit. Because your child was born before 1 October 2021, you must apply before the other parent has the last day of parental benefit. You must therefore apply before {{sisteUttaksdagMor}}.
 {{else}}
 
-You may be entitled to parental benefits. You should apply four weeks before your first day of parental benefit.
+You may be entitled to parental benefit. You should apply four weeks before your first day of parental benefit.
 
 Please, be aware of:
 
@@ -22,7 +22,7 @@ Please, be aware of:
 {{/if}}
 {{else}}
 
-You may be entitled to parental benefits. The other parent has stated that you will have parental benefits for a period that you have not applied for. In order for these days not to be lost, the person who is to be at home must apply for these days. If neither of you are going to be home, one of you must apply to postpone the period of parental benefits.
+You may be entitled to parental benefit. The other parent has stated that you will have parental benefit for a period that you have not applied for. In order for these days not to be lost, the person staying at home must apply for these days. If neither of you are going to be home, one of you must apply to postpone the period of parental benefit.
 {{/eq}}
 <br/>
 <br/>

--- a/content/templates/innvilget-foreldrepenger/avslag_en.hbs
+++ b/content/templates/innvilget-foreldrepenger/avslag_en.hbs
@@ -175,7 +175,7 @@
 {{#if kreverSammenhengendeUttak }}
 {{>punkt}}You cannot postpone parental benefit from {{periodeFom}} up to and including {{periodeTom}}.
 
-  You can only postpone parental benefits if the mother is working, studying or taking part in some other activity. You can read more about this at [nav.no/foreldrepenger](https://nav.no/foreldrepenger).
+  You can only postpone parental benefit if the mother is working, studying or taking part in some other activity. You can read more about this at [nav.no/foreldrepenger](https://nav.no/foreldrepenger).
 {{else}}
 {{>punkt}}You may not have a break in the period of parental benefit from {{periodeFom}} up to and including {{periodeTom}}.
 

--- a/content/templates/innvilget-foreldrepenger/dodt_barn_en.hbs
+++ b/content/templates/innvilget-foreldrepenger/dodt_barn_en.hbs
@@ -5,7 +5,7 @@ We have been informed that your {{#gt antallBarn 1}}child{{else}}children{{/gt}}
 This letter is to inform you that we are granting you parental benefit from {{stønadsperiodeFom}} up to and including {{stønadsperiodeTom}}.
 {{/if}}
 {{~#eq dekningsgrad 80}}
-We have changed your parental benefits from 80 per cent to 100 per cent.
+We have changed your parental benefit from 80 per cent to 100 per cent.
 {{/eq}}
 
 You will receive {{format-kroner dagsats}} kroner per day before taxes. This is {{format-kroner månedsbeløp}} kroner on average per month.

--- a/content/templates/ytelse_navn_en.hbs
+++ b/content/templates/ytelse_navn_en.hbs
@@ -1,1 +1,1 @@
-{{#eq felles.ytelseType "ES" }}lump-sum grant{{else}}{{#eq felles.ytelseType "FP" }}parental benefits{{else}}{{#eq felles.ytelseType "SVP" }}pregnancy benefits{{/eq}}{{/eq}}{{/eq}}
+{{#eq felles.ytelseType "ES" }}lump-sum grant{{else}}{{#eq felles.ytelseType "FP" }}parental benefit{{else}}{{#eq felles.ytelseType "SVP" }}pregnancy benefit{{/eq}}{{/eq}}{{/eq}}

--- a/src/test/resources/expected/foreldrepenger-avslag/foreldrepenger-avslag_mange_en.txt
+++ b/src/test/resources/expected/foreldrepenger-avslag/foreldrepenger-avslag_mange_en.txt
@@ -200,7 +200,7 @@ National identity number: 300220 12345
 
 * You cannot postpone parental benefit from 30. august 2021 up to and including 31. august 2021.
 
-  You can only postpone parental benefits if the mother is working, studying or taking part in some other activity. You can read more about this at [nav.no/foreldrepenger](https://nav.no/foreldrepenger).
+  You can only postpone parental benefit if the mother is working, studying or taking part in some other activity. You can read more about this at [nav.no/foreldrepenger](https://nav.no/foreldrepenger).
 
 * You are not entitled to parental benefit from 1. september 2021 up to and including 2. september 2021.
 

--- a/src/test/resources/expected/foreldrepenger-infotilannenforelder/foreldrepenger-infotilannenforelder_en.txt
+++ b/src/test/resources/expected/foreldrepenger-infotilannenforelder/foreldrepenger-infotilannenforelder_en.txt
@@ -5,7 +5,7 @@ Dato: 4. april 2020
 <br>
 <br>
 
-# You must apply for parental benefits in time
+# You must apply for parental benefit in time
 <p style="color:gray">
 Nav's case number: 123456789
 <br/>
@@ -16,7 +16,7 @@ National identity number: 300220 12345
 
 </p>
 
-You may be entitled to parental benefits. You must apply before 10. september 2020. This is the day the other parent has the last day of parental benefit. If you do not want to start the parental benefit period immediately after 10. september 2020, you must apply to postpone the period. If you apply at a later date, you will lose the days you did not postpone.
+You may be entitled to parental benefit. You must apply before 10. september 2020. This is the day the other parent has the last day of parental benefit. If you do not want to start the parental benefit period immediately after 10. september 2020, you must apply to postpone the period. If you apply at a later date, you will lose the days you did not postpone.
 
 **The change of parental benefit law for children born from 1 October 2021**
 For children born from and including 1 October 2021, the parents decide when they want to take out the parental benefit. Because your child was born before 1 October 2021, you must apply before the other parent has the last day of parental benefit. You must therefore apply before 10. september 2020.

--- a/src/test/resources/expected/foreldrepenger-infotilannenforelder/foreldrepenger-infotilannenforelder_ikke_sammenhengende_uttak_en.txt
+++ b/src/test/resources/expected/foreldrepenger-infotilannenforelder/foreldrepenger-infotilannenforelder_ikke_sammenhengende_uttak_en.txt
@@ -4,7 +4,7 @@ Dato: 4. april 2020
 <br>
 <br>
 <br>
-# You must apply for parental benefits in time
+# You must apply for parental benefit in time
 <p style="color:gray">
 Nav's case number: 123456789
 <br/>
@@ -13,7 +13,7 @@ Name: Dolly Duck
 National identity number: 300220 12345
 <br/>
 </p>
-You may be entitled to parental benefits. You should apply four weeks before your first day of parental benefit.
+You may be entitled to parental benefit. You should apply four weeks before your first day of parental benefit.
 Please, be aware of:
 * if a parent starts a new parental benefit period for a new child, you will lose days you have not spent
 * parental benefit must be withdrawn no later than the day before the child turns three years old

--- a/src/test/resources/expected/foreldrepenger-infotilannenforelder/foreldrepenger-infotilannenforelder_opphold_en.txt
+++ b/src/test/resources/expected/foreldrepenger-infotilannenforelder/foreldrepenger-infotilannenforelder_opphold_en.txt
@@ -5,7 +5,7 @@ Dato: 4. april 2020
 <br>
 <br>
 
-# You must apply for parental benefits in time
+# You must apply for parental benefit in time
 <p style="color:gray">
 Nav's case number: 123456789
 <br/>
@@ -16,7 +16,7 @@ National identity number: 300220 12345
 
 </p>
 
-You may be entitled to parental benefits. The other parent has stated that you will have parental benefits for a period that you have not applied for. In order for these days not to be lost, the person who is to be at home must apply for these days. If neither of you are going to be home, one of you must apply to postpone the period of parental benefits.
+You may be entitled to parental benefit. The other parent has stated that you will have parental benefit for a period that you have not applied for. In order for these days not to be lost, the person staying at home must apply for these days. If neither of you are going to be home, one of you must apply to postpone the period of parental benefit.
 
 <br/>
 <br/>

--- a/src/test/resources/expected/forlenget-saksbehandlingstid/forlenget-saksbehandlingstid_fp_FORLENGET_en.txt
+++ b/src/test/resources/expected/forlenget-saksbehandlingstid/forlenget-saksbehandlingstid_fp_FORLENGET_en.txt
@@ -5,7 +5,7 @@ Date: 4. april 2020
 <br>
 <br>
 
-# We need more time to process your application for parental benefits
+# We need more time to process your application for parental benefit
 
 <p style="color:gray">
 Nav's case number: 123456789

--- a/src/test/resources/expected/henleggelse/henleggelse_vanligBehandling_en.txt
+++ b/src/test/resources/expected/henleggelse/henleggelse_vanligBehandling_en.txt
@@ -5,7 +5,7 @@ Date: 4. april 2020
 <br>
 <br>
 
-# NAV has closed your case on parental benefits
+# NAV has closed your case on parental benefit
 <p style="color:gray">
 Nav's case number: 123456789
 <br/>
@@ -16,7 +16,7 @@ National identity number: 300220 12345
 
 </p>
 
-We have been notified that you withdraw the application for parental benefits. Your case will therefore be closed.<br/><br/>
+We have been notified that you withdraw the application for parental benefit. Your case will therefore be closed.<br/><br/>
 
 **Do you have questions?**<br/>
 You will find useful information at [nav.no/familie](https://nav.no/familie).

--- a/src/test/resources/expected/innsyn/innsyn_avvist_en.txt
+++ b/src/test/resources/expected/innsyn/innsyn_avvist_en.txt
@@ -5,7 +5,7 @@ Date: 4. april 2020
 <br>
 <br>
 
-# NAV has rejected your request for access to your case regarding pregnancy benefits
+# NAV has rejected your request for access to your case regarding pregnancy benefit
 <p style="color:gray">
 Nav's case number: 123456789
 <br/>

--- a/src/test/resources/expected/innvilget-foreldrepenger/avslag/førstegangsbehandling_avslag_en.txt
+++ b/src/test/resources/expected/innvilget-foreldrepenger/avslag/førstegangsbehandling_avslag_en.txt
@@ -76,7 +76,7 @@
 * You are not entitled to parental benefit from 26. november 2021 up to and including 17. januar 2022 because your child is 3 years old.
 * You cannot postpone parental benefit from 26. november 2021 up to and including 17. januar 2022 because there are no more days left of the parental benefit period.
 * You cannot postpone parental benefit from 26. november 2021 up to and including 17. januar 2022.
-  You can only postpone parental benefits if the mother is working, studying or taking part in some other activity. You can read more about this at [nav.no/foreldrepenger](https://nav.no/foreldrepenger).
+  You can only postpone parental benefit if the mother is working, studying or taking part in some other activity. You can read more about this at [nav.no/foreldrepenger](https://nav.no/foreldrepenger).
 * You are not entitled to parental benefit from 26. november 2021 up to and including 17. januar 2022.
   To get more days of parental benefit, the other parent must be working, studying or taking part in some other activity. You can read more about this at [nav.no/foreldrepenger](https://nav.no/foreldrepenger).
 * You are not entitled to parental benefit from 26. november 2021 up to and including 17. januar 2022.


### PR DESCRIPTION
Rettet alle engelske tekster til parental benefit, og ikke parental benefits. Det samme for pregnansy benefit. Har også  forebedret engelsk tekst for varsling revurdering.