### PR TITLE
TFP-4658 Rettelse gradering foreldrepenger innvilget

### DIFF
--- a/content/templates/innvilget-foreldrepenger/innvilget_en.hbs
+++ b/content/templates/innvilget-foreldrepenger/innvilget_en.hbs
@@ -89,7 +89,7 @@
 
 
 {{#each annenAktivitetsliste}}
-{{#if (and (eq this.aktivitetStatus "FL") (eq this.gradering true))}} {{#if @../innvilget}}
+{{#if (and (eq this.aktivitetStatus "FRILANSER") (eq this.gradering true))}} {{#if @../innvilget}}
 {{>punkt}}You are taking {{trim-decimal this.utbetalingsgrad}} per cent parental benefit from {{@../periodeFom}} up to and including {{@../periodeTom}} because you are working {{trim-decimal this.prosentArbeid}} per cent. In this period you will receive {{format-kroner @../periodeDagsats}} kroner per day before taxes.
 {{/if}}{{/if}}
 {{/each}}

--- a/content/templates/innvilget-foreldrepenger/innvilget_nb.hbs
+++ b/content/templates/innvilget-foreldrepenger/innvilget_nb.hbs
@@ -89,7 +89,7 @@
 
 
 {{#each annenAktivitetsliste}}
-{{#if (and (eq this.aktivitetStatus "FL") (eq this.gradering true))}} {{#if @../innvilget}}
+{{#if (and (eq this.aktivitetStatus "FRILANSER") (eq this.gradering true))}} {{#if @../innvilget}}
 {{>punkt}}Du tar ut {{trim-decimal this.utbetalingsgrad}} prosent foreldrepenger fra og med {{@../periodeFom}} til og med {{@../periodeTom}} fordi du jobber {{trim-decimal this.prosentArbeid}} prosent. I denne perioden får du {{format-kroner @../periodeDagsats}} kroner per dag før skatt.
 {{/if}}{{/if}}
 {{/each}}

--- a/content/templates/innvilget-foreldrepenger/innvilget_nn.hbs
+++ b/content/templates/innvilget-foreldrepenger/innvilget_nn.hbs
@@ -89,7 +89,7 @@
 
 
 {{#each annenAktivitetsliste}}
-{{#if (and (eq this.aktivitetStatus "FL") (eq this.gradering true))}} {{#if @../innvilget}}
+{{#if (and (eq this.aktivitetStatus "FRILANSER") (eq this.gradering true))}} {{#if @../innvilget}}
 {{>punkt}}Du tek ut {{trim-decimal this.utbetalingsgrad}} prosent foreldrepengar frå og med {{@../periodeFom}} til og med {{@../periodeTom}} fordi du jobbar {{trim-decimal this.prosentArbeid}} prosent. I denne perioden får du {{format-kroner @../periodeDagsats}} kroner per dag før skatt.
 {{/if}}{{/if}}
 {{/each}}

--- a/content/templates/innvilget-foreldrepenger/testdata/innvilget/førstegangsbehandling_annenaktivitet_næring.json
+++ b/content/templates/innvilget-foreldrepenger/testdata/innvilget/førstegangsbehandling_annenaktivitet_næring.json
@@ -58,25 +58,25 @@
       "prioritertUtbetalingsgrad": 50.0,
       "annenAktivitetsliste": [
         {
-          "aktivitetStatus": "FL",
+          "aktivitetStatus": "FRILANSER",
           "gradering": true,
           "utbetalingsgrad": 50.0,
           "prosentArbeid": 40.0
         },
         {
-          "aktivitetStatus": "FL",
+          "aktivitetStatus": "FRILANSER",
           "gradering": false,
           "utbetalingsgrad": 10.0,
           "prosentArbeid": 5.0
         },
         {
-          "aktivitetStatus": "FL",
+          "aktivitetStatus": "FRILANSER",
           "gradering": true,
           "utbetalingsgrad": 20.0,
           "prosentArbeid": 10.0
         },
         {
-          "aktivitetStatus": "AT",
+          "aktivitetStatus": "ARBEIDSTAKER",
           "gradering": true,
           "utbetalingsgrad": 40.0,
           "prosentArbeid": 30.0
@@ -93,7 +93,7 @@
       "prioritertUtbetalingsgrad": 90.0,
       "annenAktivitetsliste": [
         {
-          "aktivitetStatus": "FL",
+          "aktivitetStatus": "FRILANSER",
           "gradering": true,
           "utbetalingsgrad": 90.0,
           "prosentArbeid": 85.0

--- a/content/templates/innvilget-foreldrepenger/testdata/utbetaling/førstegangsbehandling_delvis_refusjon.json
+++ b/content/templates/innvilget-foreldrepenger/testdata/utbetaling/førstegangsbehandling_delvis_refusjon.json
@@ -122,12 +122,12 @@
   "harBruktBruttoBeregningsgrunnlag": true,
   "beregningsgrunnlagregler": [
     {
-      "aktivitetStatus": "AT",
+      "aktivitetStatus": "ARBEIDSTAKER",
       "antallArbeidsgivereIBeregningUtenEtterlønnSluttpakke": 1,
       "snNyoppstartet": false,
       "andelListe": [
         {
-          "aktivitetStatus": "AT",
+          "aktivitetStatus": "ARBEIDSTAKER",
           "arbeidsgiverNavn": "ARBEIDSGIVER AS",
           "dagsats": 2209,
           "månedsinntekt": 47879,

--- a/content/templates/innvilget-foreldrepenger/testdata/utbetaling/førstegangsbehandling_full_refusjon.json
+++ b/content/templates/innvilget-foreldrepenger/testdata/utbetaling/førstegangsbehandling_full_refusjon.json
@@ -122,12 +122,12 @@
   "harBruktBruttoBeregningsgrunnlag": true,
   "beregningsgrunnlagregler": [
     {
-      "aktivitetStatus": "AT",
+      "aktivitetStatus": "ARBEIDSTAKER",
       "antallArbeidsgivereIBeregningUtenEtterlønnSluttpakke": 1,
       "snNyoppstartet": false,
       "andelListe": [
         {
-          "aktivitetStatus": "AT",
+          "aktivitetStatus": "ARBEIDSTAKER",
           "arbeidsgiverNavn": "ARBEIDSGIVER AS",
           "dagsats": 2209,
           "månedsinntekt": 47879,

--- a/content/templates/innvilget-foreldrepenger/testdata/utbetaling/førstegangsbehandling_ingen_refusjon.json
+++ b/content/templates/innvilget-foreldrepenger/testdata/utbetaling/førstegangsbehandling_ingen_refusjon.json
@@ -126,12 +126,12 @@
   "harBruktBruttoBeregningsgrunnlag": true,
   "beregningsgrunnlagregler": [
     {
-      "aktivitetStatus": "AT",
+      "aktivitetStatus": "ARBEIDSTAKER",
       "antallArbeidsgivereIBeregningUtenEtterlønnSluttpakke": 1,
       "snNyoppstartet": false,
       "andelListe": [
         {
-          "aktivitetStatus": "AT",
+          "aktivitetStatus": "ARBEIDSTAKER",
           "arbeidsgiverNavn": "ARBEIDSGIVER AS",
           "dagsats": 2209,
           "månedsinntekt": 47879,


### PR DESCRIPTION
Rettet at graderingstekst i innvilget malen sjekket på aktivitetstatus "FL" og ikke "FRILANSER". Gjorde at perioder ikke ble med i brevet.