### PR TITLE
NOJIRA: Bruker ##### / h5 til å rendre underoverskrifter i stedet for…

### DIFF
--- a/content/formats/pdf/style.css
+++ b/content/formats/pdf/style.css
@@ -77,6 +77,10 @@ h3 {
     margin: 10mm 0 1.5mm 0;
 }
 
+h5 {
+    margin-bottom: -2.5mm;
+}
+
 p {
     font-size: 14px;
     margin: 3mm 0 2mm 0;

--- a/content/templates/engangsstonad-avslag/template_en.hbs
+++ b/content/templates/engangsstonad-avslag/template_en.hbs
@@ -113,7 +113,7 @@ This decision has been made pursuant to section 21-3 of the National Insurance A
 {{/each}}
 <br/>
 
-**You have the right to appeal**<br/>
+##### You have the right to appeal
 You may appeal within {{klagefristUker}} weeks from the date you received the decision. You will find the relevant form and information at [nav.no/klage](https://nav.no/klage).
 <br/>
 <br/>

--- a/content/templates/engangsstonad-avslag/template_nb.hbs
+++ b/content/templates/engangsstonad-avslag/template_nb.hbs
@@ -114,7 +114,7 @@ Vedtaket er gjort etter folketrygdloven § 21-3.
 {{/each}}
 <br/>
 
-**Du har rett til å klage**<br/>
+##### Du har rett til å klage
 Du kan klage innen {{klagefristUker}} uker fra den datoen du mottok vedtaket. Du finner skjema og informasjon på [nav.no/klage](https://nav.no/klage).
 <br/>
 <br/>

--- a/content/templates/engangsstonad-avslag/template_nn.hbs
+++ b/content/templates/engangsstonad-avslag/template_nn.hbs
@@ -113,7 +113,7 @@ Vedtaket er gjort etter folketrygdlova § 21-3.
 {{/each}}
 <br/>
 
-**Du har rett til å klage**<br/>
+##### Du har rett til å klage
 Du kan klage innan {{klagefristUker}} veker frå den datoen du fekk vedtaket. Du finn skjema og informasjon på [nav.no/klage](https://nav.no/klage).
 <br/>
 <br/>

--- a/content/templates/engangsstonad-innvilgelse/template_en.hbs
+++ b/content/templates/engangsstonad-innvilgelse/template_en.hbs
@@ -35,7 +35,7 @@ The decision has been made pursuant to section 14-17 of the National Insurance A
 {{/if}}
 <br/>
 
-**You have the right to appeal**<br/>
+##### You have the right to appeal
 You may appeal within {{klagefristUker}} weeks from the date you received the decision. You will find the relevant form and information at [nav.no/klage](https://nav.no/klage).
 <br/>
 <br/>

--- a/content/templates/engangsstonad-innvilgelse/template_nb.hbs
+++ b/content/templates/engangsstonad-innvilgelse/template_nb.hbs
@@ -35,7 +35,7 @@ Vedtaket er gjort etter folketrygdloven § 14-17 og forvaltningsloven § 35.<br/
 {{/if}}
 <br/>
 
-**Du har rett til å klage**<br/>
+##### Du har rett til å klage
 Du kan klage innen {{klagefristUker}} uker fra den datoen du mottok vedtaket. Du finner skjema og informasjon på [nav.no/klage](https://nav.no/klage).
 <br/>
 <br/>

--- a/content/templates/engangsstonad-innvilgelse/template_nn.hbs
+++ b/content/templates/engangsstonad-innvilgelse/template_nn.hbs
@@ -35,7 +35,7 @@ Vedtaket er gjort etter folketrygdlova § 14-17 og forvaltingslova § 35.<br/>
 {{/if}}
 <br/>
 
-**Du har rett til å klage**<br/>
+##### Du har rett til å klage
 Du kan klage innan {{klagefristUker}} veker frå den datoen du fekk vedtaket. Du finn skjema og informasjon på [nav.no/klage](https://nav.no/klage).
 <br/>
 <br/>

--- a/content/templates/footer_en.hbs
+++ b/content/templates/footer_en.hbs
@@ -1,11 +1,11 @@
-**You have right of access**<br/>
+##### You have right of access
 Go to [nav.no/dittnav](https://nav.no/dittnav) to see the documents in your case.
 <br/>
 <br/>
 <br/>
 <div style="break-inside: avoid; page-break-inside: avoid">
 
-**Do you have questions?**<br/>
+##### Do you have questions?
 You will find useful information at [nav.no/familie](https://nav.no/familie).
 <br/>
 <br/>

--- a/content/templates/footer_nb.hbs
+++ b/content/templates/footer_nb.hbs
@@ -1,11 +1,11 @@
-**Du har rett til innsyn**<br/>
+##### Du har rett til innsyn
 På [nav.no/dittnav](https://nav.no/dittnav) kan du se dokumentene i saken din.
 <br/>
 <br/>
 <br/>
 <div style="break-inside: avoid; page-break-inside: avoid">
 
-**Har du spørsmål?**<br/>
+##### Har du spørsmål?
 Du finner nyttig informasjon på [nav.no/familie](https://nav.no/familie).
 <br/>
 <br/>

--- a/content/templates/footer_nn.hbs
+++ b/content/templates/footer_nn.hbs
@@ -1,11 +1,11 @@
-**Du har rett til innsyn**<br/>
+##### Du har rett til innsyn
 På [nav.no/dittnav](https://nav.no/dittnav) kan du sjå dokumenta i saka di.
 <br/>
 <br/>
 <br/>
 <div style="break-inside: avoid; page-break-inside: avoid">
 
-**Har du spørsmål?**<br/>
+##### Har du spørsmål?
 Du finn nyttig informasjon på [nav.no/familie](https://nav.no/familie).
 <br/>
 <br/>

--- a/content/templates/foreldrepenger-annullert/template_en.hbs
+++ b/content/templates/foreldrepenger-annullert/template_en.hbs
@@ -19,9 +19,7 @@ When there are 4 weeks left until you are to withdraw your parental benefit, you
 
 The decision has been made pursuant to section 14-6, 14-7, 14-9, 14-10, 14-11 and 14-12 of the National Insurance Act.
 
-<br/>
-
-**You have the right to appeal**<br/>
+##### You have the right to appeal
 You may appeal within {{klagefristUker}} weeks from the date you received the decision. You will find the relevant form and information at [nav.no/klage](https://nav.no/klage).
 <br/>
 <br/>

--- a/content/templates/foreldrepenger-annullert/template_nb.hbs
+++ b/content/templates/foreldrepenger-annullert/template_nb.hbs
@@ -19,9 +19,7 @@ Når det er 4 uker igjen til du skal ta ut foreldrepenger, må arbeidsgiveren di
 
 Vedtaket er gjort etter folketrygdloven §§ 14-6, 14-7, 14-9, 14-10, 14-11 og 14-12.
 
-<br/>
-
-**Du har rett til å klage**<br/>
+##### Du har rett til å klage
 Du kan klage innen {{klagefristUker}} uker fra den datoen du mottok vedtaket. Du finner skjema og informasjon på [nav.no/klage](https://nav.no/klage).
 <br/>
 <br/>

--- a/content/templates/foreldrepenger-annullert/template_nn.hbs
+++ b/content/templates/foreldrepenger-annullert/template_nn.hbs
@@ -19,9 +19,7 @@ Når det er 4 veker igjen til du skal ta ut foreldrepengar, må arbeidsgivaren d
 
 Vedtaket er gjort etter folketrygdlova §§ 14-6, 14-7, 14-9, 14-10, 14-11 og 14-12.
 
-<br/>
-
-**Du har rett til å klage**<br/>
+##### Du har rett til å klage
 Du kan klage innan {{klagefristUker}} veker frå den datoen du fekk vedtaket. Du finn skjema og informasjon på [nav.no/klage](https://nav.no/klage).
 <br/>
 <br/>

--- a/content/templates/foreldrepenger-avslag/template_en.hbs
+++ b/content/templates/foreldrepenger-avslag/template_en.hbs
@@ -5,7 +5,7 @@
 #  NAV has denied your application for parental benefit
 {{> brukerdetaljer_en }}
 
-**We have denied the following**
+##### We have denied the following
 {{#if felles.fritekst}}
 {{felles.fritekst}}
 {{else}}
@@ -376,7 +376,7 @@ The decision has been made in accordance with the National Insurance Act Section
 
 <br/>
 
-**You have the right to appeal**<br/>
+##### You have the right to appeal
 You may appeal within {{klagefristUker}} weeks from the date you received the decision. You will find the relevant form and information at [nav.no/klage](https://nav.no/klage).
 <br/>
 <br/>

--- a/content/templates/foreldrepenger-avslag/template_nb.hbs
+++ b/content/templates/foreldrepenger-avslag/template_nb.hbs
@@ -5,7 +5,7 @@
 #  NAV har avslått søknaden din om foreldrepenger
 {{> brukerdetaljer_nb }}
 
-**Dette har vi avslått**
+##### Dette har vi avslått
 {{#if felles.fritekst}}
 {{felles.fritekst}}
 {{else}}
@@ -377,7 +377,7 @@ Vedtaket er gjort etter folketrygdloven {{lovhjemmelForAvslag}}.
 
 <br/>
 
-**Du har rett til å klage**<br/>
+##### Du har rett til å klage
 Du kan klage innen {{klagefristUker}} uker fra den datoen du mottok vedtaket. Du finner skjema og informasjon på [nav.no/klage](https://nav.no/klage).
 <br/>
 <br/>

--- a/content/templates/foreldrepenger-avslag/template_nn.hbs
+++ b/content/templates/foreldrepenger-avslag/template_nn.hbs
@@ -5,7 +5,7 @@
 #  NAV har avslått søknaden din om foreldrepengar
 {{> brukerdetaljer_nn }}
 
-**Dette har vi avslått**
+##### Dette har vi avslått
 {{#if felles.fritekst}}
 {{felles.fritekst}}
 {{else}}
@@ -376,7 +376,7 @@ Vedtaket er gjort etter folketrygdlova {{lovhjemmelForAvslag}}.
 
 <br/>
 
-**Du har rett til å klage**<br/>
+##### Du har rett til å klage
 Du kan klage innan {{klagefristUker}} veker frå den datoen du fekk vedtaket. Du finn skjema og informasjon på [nav.no/klage](https://nav.no/klage).
 <br/>
 <br/>

--- a/content/templates/foreldrepenger-infotilannenforelder/template_en.hbs
+++ b/content/templates/foreldrepenger-infotilannenforelder/template_en.hbs
@@ -9,7 +9,7 @@
 
 You may be entitled to parental benefit. You must apply before {{sisteUttaksdagMor}}. This is the day the other parent has the last day of parental benefit. If you do not want to start the parental benefit period immediately after {{sisteUttaksdagMor}}, you must apply to postpone the period. If you apply at a later date, you will lose the days you did not postpone.
 
-**The change of parental benefit law for children born from 1 October 2021**
+##### The change of parental benefit law for children born from 1 October 2021
 For children born from and including 1 October 2021, the parents decide when they want to take out the parental benefit. Because your child was born before 1 October 2021, you must apply before the other parent has the last day of parental benefit. You must therefore apply before {{sisteUttaksdagMor}}.
 {{else}}
 
@@ -25,9 +25,8 @@ Please, be aware of:
 You may be entitled to parental benefit. The other parent has stated that you will have parental benefit for a period that you have not applied for. In order for these days not to be lost, the person staying at home must apply for these days. If neither of you are going to be home, one of you must apply to postpone the period of parental benefit.
 {{/eq}}
 <br/>
-<br/>
 
-**Do you have questions?**<br/>
+##### Do you have questions?
 You will find useful information at [nav.no/familie](https://nav.no/familie).
 <br/>
 <br/>

--- a/content/templates/foreldrepenger-infotilannenforelder/template_nb.hbs
+++ b/content/templates/foreldrepenger-infotilannenforelder/template_nb.hbs
@@ -9,7 +9,7 @@
 
 Du kan ha rett til foreldrepenger. Du må søke før {{sisteUttaksdagMor}}. Dette er den dagen den andre forelderen har siste dag med foreldrepenger. Hvis du ikke ønsker å starte foreldrepengeperioden rett etter {{sisteUttaksdagMor}}, må du søke om å utsette perioden. Søker du på et senere tidspunkt, mister du de dagene du har søkt for sent.
 
-**Lovendring av foreldrepengeordningen gjelder for de som har fått barn fra og med 1. oktober 2021**
+##### Lovendring av foreldrepengeordningen gjelder for de som har fått barn fra og med 1. oktober 2021
 For de som har fått barn fra og med 1. oktober 2021 bestemmer foreldrene selv når de vil ta ut foreldrepengene. Fordi du har fått barn før 01.10.2021, må du søke innen den andre forelderen har siste dag med foreldrepenger. Du må derfor søke før {{sisteUttaksdagMor}}.
 {{else}}
 
@@ -25,9 +25,8 @@ Vi gjør oppmerksom på:
 Du kan ha rett til foreldrepenger. Den andre forelderen har opplyst at du skal ha foreldrepenger i en periode som du ikke har søkt om. For at disse dagene ikke skal gå tapt må den som skal være hjemme søke om disse dagene. Hvis ingen av dere skal være hjemme må en av dere søke om utsettelse av foreldrepengene.
 {{/eq}}
 <br/>
-<br/>
 
-**Har du spørsmål?**<br/>
+##### Har du spørsmål?
 Du finner nyttig informasjon på [nav.no/familie](https://nav.no/familie).
 <br/>
 <br/>

--- a/content/templates/foreldrepenger-infotilannenforelder/template_nn.hbs
+++ b/content/templates/foreldrepenger-infotilannenforelder/template_nn.hbs
@@ -9,7 +9,7 @@
 
 Du kan ha rett til foreldrepengar. Du må søkje før {{sisteUttaksdagMor}}. Dette er den dagen den andre forelderen har siste dag med foreldrepengar. Dersom du ikkje ynskjer å starte foreldrepengeperioden rett etter {{sisteUttaksdagMor}}, må du søkje om å utsetje perioden. Søkjer du på eit seinare tidspunkt, mister du dei dagane du har søkt for seint.
 
-**Lovendring av foreldrepengeordninga gjelder for barn du fekk frå og med 1. oktober 2021**
+##### Lovendring av foreldrepengeordninga gjelder for barn du fekk frå og med 1. oktober 2021
 For dei som fekk barn frå og med 1.oktober 2021, bestemmer foreldrane sjølve når dei vil ta ut foreldrepengane. Fordi du har fått barn før 01.10.2021, må du søkje innan den andre forelderen har siste dag med foreldrepengar. Du må derfor søkje før {{sisteUttaksdagMor}}.
 {{else}}
 
@@ -25,9 +25,8 @@ Vær oppmerksam på:
 Du kan ha rett til foreldrepengar. Den andre forelderen har opplyst at du skal ha foreldrepengar i ein periode som du ikkje har søkt om. For at disse dagane ikkje skal gå tapt må den som skal vere heime søkje om desse dagane. Dersom ingen av dykk skal vere heime må ein av dykk søkje om utsetjing av foreldrepengane.
 {{/eq}}
 <br/>
-<br/>
 
-**Har du spørsmål?**<br/>
+##### Har du spørsmål?
 Du finn nyttig informasjon på [nav.no/familie](https://nav.no/familie).
 <br/>
 <br/>

--- a/content/templates/foreldrepenger-opphor/template_nb.hbs
+++ b/content/templates/foreldrepenger-opphor/template_nb.hbs
@@ -20,7 +20,7 @@ Klagefristen er {{klagefristUker}} uker fra den datoen dødsboet fikk brevet.
 # Du har ikke lenger rett til foreldrepenger
 {{> brukerdetaljer_nb }}
 
-**Dette har vi avslått**
+##### Dette har vi avslått
 {{~#each avslagÅrsaker}}
 {{~#switch this}}
 {{#case "1035" }}
@@ -87,7 +87,7 @@ Du hadde ikke rett til foreldrepenger fordi du ikke var medlem i folketrygden p�
 
 Vedtaket er gjort etter folketrygdloven {{lovhjemmelForAvslag}} og forvaltningsloven § 35.
 
-**Du har rett til å klage**<br/>
+##### Du har rett til å klage
 Du kan klage innen {{klagefristUker}} uker fra den datoen du mottok vedtaket. Du finner skjema og informasjon på [nav.no/klage](https://nav.no/klage).
 <br/>
 <br/>

--- a/content/templates/henleggelse/template_en.hbs
+++ b/content/templates/henleggelse/template_en.hbs
@@ -32,7 +32,7 @@ We have been notified that you withdraw your appeal on {{>ytelse_navn_en}}. Your
 We have been notified that you withdraw your request of access of your case. NAV will therefore end further processing of your inquiry.<br/><br/>
 {{/if}}
 
-**Do you have questions?**<br/>
+##### Do you have questions?
 You will find useful information at [nav.no/familie](https://nav.no/familie).
 <br/>
 <br/>

--- a/content/templates/henleggelse/template_nb.hbs
+++ b/content/templates/henleggelse/template_nb.hbs
@@ -32,7 +32,7 @@ Vi har fått beskjed om at du trekker anken på {{>ytelse_navn_nb}}, og avslutte
 Vi har fått beskjed om at du trekker forespørselen om innsyn i saken, og avslutter derfor behandlingen av henvendelsen din.<br/><br/>
 {{/if}}
 
-**Har du spørsmål?**<br/>
+##### Har du spørsmål?
 Du finner nyttig informasjon på [nav.no/familie](https://nav.no/familie).
 <br/>
 <br/>

--- a/content/templates/henleggelse/template_nn.hbs
+++ b/content/templates/henleggelse/template_nn.hbs
@@ -32,7 +32,7 @@ Vi har fått beskjed om at du trekkjer anken på {{>ytelse_navn_nn}}, og avslutt
 Vi har fått beskjed om at du trekker spørsmålet om innsyn i saka, og avsluttar derfor behandlinga av førespurnaden din.<br/><br/>
 {{/if}}
 
-**Har du spørsmål?**<br/>
+##### Har du spørsmål?
 Du finn nyttig informasjon på [nav.no/familie](https://nav.no/familie).
 <br/>
 <br/>

--- a/content/templates/hilsen_en.hbs
+++ b/content/templates/hilsen_en.hbs
@@ -9,9 +9,9 @@ This case has been electronically processed by our administration system, which 
 <br/><br/>
 {{#if felles.erKopi}}
 
-**This is a copy, the orginal has been sent to the guardian**.
+##### This is a copy, the orginal has been sent to the guardian.
 {{else}}
 
-**A copy of this letter has been sent to the applicant for information**.
+##### A copy of this letter has been sent to the applicant for information.
 {{/if}}
 {{/if}}

--- a/content/templates/hilsen_nb.hbs
+++ b/content/templates/hilsen_nb.hbs
@@ -9,9 +9,9 @@ Vedtaket har blitt automatisk saksbehandlet av vårt fagsystem. Vedtaksbrevet er
 <br/><br/>
 {{#if felles.erKopi}}
 
-**Dette er en kopi, orginal er sendt til verge**.
+##### Dette er en kopi, orginal er sendt til verge.
 {{else}}
 
-**Kopi av dette brevet er sendt søker til orientering**.
+##### Kopi av dette brevet er sendt søker til orientering.
 {{/if}}
 {{/if}}

--- a/content/templates/hilsen_nn.hbs
+++ b/content/templates/hilsen_nn.hbs
@@ -9,9 +9,9 @@ Vedtaket har blitt automatisk saksbehandla av fagsystemet vårt. Det er derfor i
 <br/><br/>
 {{#if felles.erKopi}}
 
-**Dette er ein kopi, orginal er sendt til verje**.
+##### Dette er ein kopi, orginal er sendt til verje.
 {{else}}
 
-**Kopi av dette brevet er send søkar til orientering**.
+##### Kopi av dette brevet er send søkar til orientering.
 {{/if}}
 {{/if}}

--- a/content/templates/innhente-opplysninger/template_en.hbs
+++ b/content/templates/innhente-opplysninger/template_en.hbs
@@ -28,17 +28,16 @@ We received your complaint concerning {{> ytelse_navn_en}} {{søknadDato}}, but 
     {{/if}}
 {{/if}}{{/if}}
 
-**You have to send us**
-<br/>
+##### You have to send us
 {{felles.fritekst}}
+<br/>
 <br/>
 
 {{#if (and (eq klage true) (eq felles.behandlesAvKA true))}}
 The documentation must be sent at [nav.no/klage](https://nav.no/klage). Choose NAV-enhet: NAV Klageinstans Midt-Norge.
 {{/if}}
 
-**Your application can be turned down**
-<br/>
+##### Your application can be turned down
 {{#if førstegangsbehandling}}If you do not send us the requested documentation before {{fristDato}}, your application can be turned down.
 {{else}}If you do not send us the requested documentation before {{fristDato}}, we will process your case with the information that we have.
 {{/if}}

--- a/content/templates/innhente-opplysninger/template_nb.hbs
+++ b/content/templates/innhente-opplysninger/template_nb.hbs
@@ -28,17 +28,16 @@ Vi fikk klagen din på {{> ytelse_navn_nb}} {{søknadDato}}, men mangler opplysn
     {{/if}}
 {{/if}}{{/if}}
 
-**Du må sende oss**
-<br/>
+##### Du må sende oss
 {{felles.fritekst}}
+<br/>
 <br/>
 
 {{#if (and (eq klage true) (eq felles.behandlesAvKA true))}}
 Du sender dokumentasjonen til oss på [nav.no/klage](https://nav.no/klage). Velg NAV-enhet: NAV Klageinstans Midt-Norge.
 {{/if}}
 
-**Søknaden kan bli avslått**
-<br/>
+##### Søknaden kan bli avslått
 {{#if førstegangsbehandling}}Hvis vi ikke får opplysningene innen {{fristDato}}, kan søknaden bli avslått.
 {{else}}Hvis du ikke sender oss dette innen {{fristDato}}, behandler vi saken med de opplysningene vi har.
 {{/if}}

--- a/content/templates/innhente-opplysninger/template_nn.hbs
+++ b/content/templates/innhente-opplysninger/template_nn.hbs
@@ -28,17 +28,16 @@ Vi fekk klagen din på {{> ytelse_navn_nn}} {{søknadDato}}, men manglar opplysn
     {{/if}}
 {{/if}}{{/if}}
 
-**Du må sende oss**
-<br/>
+##### Du må sende oss
 {{felles.fritekst}}
+<br/>
 <br/>
 
 {{#if (and (eq klage true) (eq felles.behandlesAvKA true))}}
 Du sender dokumentasjonen til oss på [nav.no/klage](https://nav.no/klage). Vel NAV-eining: NAV Klageinstans Midt-Noreg.
 {{/if}}
 
-**Søknaden kan bli avslått**
-<br/>
+##### Søknaden kan bli avslått
 {{#if førstegangsbehandling}}Dersom vi ikkje får opplysningane innan {{fristDato}}, kan søknaden bli avslått.
 {{else}}Dersom du ikkje sender oss dette innan {{fristDato}}, behandlar vi saka di med dei opplysningane vi har.
 {{/if}}

--- a/content/templates/innsyn/template_en.hbs
+++ b/content/templates/innsyn/template_en.hbs
@@ -32,14 +32,14 @@ This is pursuant to section 18 of the Public Administration Act.
 {{/eq}}
 <br/>
 
-**You have the right to appeal**<br/>
+##### You have the right to appeal
 You may appeal within {{klagefrist}} weeks from the date you received the decision. You will find the relevant form and information at [nav.no/klage](https://nav.no/klage).
 
 The right to appeal regarding access is pursuant to section 21 of the Public Administration Act.
 <br/>
 <br/>
 <br/>
-**Do you have questions?**<br/>
+##### Do you have questions?
 You will find useful information at [nav.no/familie](https://nav.no/familie).
 <br/>
 <br/>

--- a/content/templates/innsyn/template_nb.hbs
+++ b/content/templates/innsyn/template_nb.hbs
@@ -32,14 +32,14 @@ Dette går fram av forvaltningsloven § 18.
 {{/eq}}
 <br/>
 
-**Du har rett til å klage**<br/>
+##### Du har rett til å klage
 Du kan klage innen {{klagefrist}} uker fra den datoen du mottok vedtaket. Du finner skjema og informasjon på [nav.no/klage](https://nav.no/klage)
 
 Retten til å klage på innsyn går fram av forvaltningsloven § 21.
 <br/>
 <br/>
 <br/>
-**Har du spørsmål?**<br/>
+##### Har du spørsmål?
 Du finner nyttig informasjon på [nav.no/familie](https://nav.no/familie).
 <br/>
 <br/>

--- a/content/templates/innsyn/template_nn.hbs
+++ b/content/templates/innsyn/template_nn.hbs
@@ -32,14 +32,14 @@ Dette går fram av forvaltningslova § 18.
 {{/eq}}
 <br/>
 
-**Du har rett til å klage**<br/>
+##### Du har rett til å klage
 Du kan klage innan {{klagefrist}} veker frå den datoen du fekk brevet. Du finn skjema og informasjon på [nav.no/klage](https://nav.no/klage)
 
 Retten til å klage på innsyn går fram av forvaltningslova § 21.
 <br/>
 <br/>
 <br/>
-**Har du spørsmål?**<br/>
+##### Har du spørsmål?
 Du finn nyttig informasjon på [nav.no/familie](https://nav.no/familie).
 <br/>
 <br/>

--- a/content/templates/innvilget-foreldrepenger/avslag_en.hbs
+++ b/content/templates/innvilget-foreldrepenger/avslag_en.hbs
@@ -1,6 +1,6 @@
 <br/>
 
-**We have denied the following**
+##### We have denied the following
 
 {{~#* inline "punkt" ~}}
 {{~#gt antallAvslåttePerioder 1}}* {{/gt}}

--- a/content/templates/innvilget-foreldrepenger/avslag_nb.hbs
+++ b/content/templates/innvilget-foreldrepenger/avslag_nb.hbs
@@ -1,6 +1,6 @@
 <br/>
 
-**Dette har vi avslått**
+##### Dette har vi avslått
 
 {{~#* inline "punkt" ~}}
 {{~#gt antallAvslåttePerioder 1}}* {{/gt}}

--- a/content/templates/innvilget-foreldrepenger/avslag_nn.hbs
+++ b/content/templates/innvilget-foreldrepenger/avslag_nn.hbs
@@ -1,6 +1,6 @@
 <br/>
 
-**Dette har vi avslått**
+##### Dette har vi avslått
 
 {{~#* inline "punkt" ~}}
 {{~#gt antallAvslåttePerioder 1}}* {{/gt}}

--- a/content/templates/innvilget-foreldrepenger/beregning_en.hbs
+++ b/content/templates/innvilget-foreldrepenger/beregning_en.hbs
@@ -1,6 +1,6 @@
 <br/>
 
-**Income we have used in the calculation**<br/>
+##### Income we have used in the calculation
 
 {{~#if felles.fritekst}}
 {{felles.fritekst}}

--- a/content/templates/innvilget-foreldrepenger/beregning_nb.hbs
+++ b/content/templates/innvilget-foreldrepenger/beregning_nb.hbs
@@ -1,6 +1,6 @@
 <br/>
 
-**Inntekt vi har brukt i beregningen**<br/>
+##### Inntekt vi har brukt i beregningen
 
 {{~#if felles.fritekst}}
 {{felles.fritekst}}

--- a/content/templates/innvilget-foreldrepenger/beregning_nn.hbs
+++ b/content/templates/innvilget-foreldrepenger/beregning_nn.hbs
@@ -1,6 +1,6 @@
 <br/>
 
-**Inntekt vi har brukt i berekninga**<br/>
+##### Inntekt vi har brukt i berekninga
 
 {{~#if felles.fritekst}}
 {{felles.fritekst}}

--- a/content/templates/innvilget-foreldrepenger/innvilget_en.hbs
+++ b/content/templates/innvilget-foreldrepenger/innvilget_en.hbs
@@ -2,7 +2,7 @@
 
 {{~#gt antallInnvilgedePerioder 0}}
 
-**We have granted the following**
+##### We have granted the following
 {{/gt}}
 
 {{~#* inline "punkt" ~}}

--- a/content/templates/innvilget-foreldrepenger/innvilget_nb.hbs
+++ b/content/templates/innvilget-foreldrepenger/innvilget_nb.hbs
@@ -2,7 +2,7 @@
 
 {{~#gt antallInnvilgedePerioder 0}}
 
-**Dette har vi innvilget**
+##### Dette har vi innvilget
 {{/gt}}
 
 {{~#* inline "punkt" ~}}

--- a/content/templates/innvilget-foreldrepenger/innvilget_nn.hbs
+++ b/content/templates/innvilget-foreldrepenger/innvilget_nn.hbs
@@ -2,7 +2,7 @@
 
 {{~#gt antallInnvilgedePerioder 0}}
 
-**Dette har vi innvilga**
+##### Dette har vi innvilga
 {{/gt}}
 
 {{~#* inline "punkt" ~}}

--- a/content/templates/innvilget-foreldrepenger/template_en.hbs
+++ b/content/templates/innvilget-foreldrepenger/template_en.hbs
@@ -45,7 +45,7 @@ There are {{disponibleDager}} {{#eq disponibleDager 1}}day{{else}}days{{/eq}} le
 {{~#each arbeidsforholdsliste}}
 {{#if @..first}}
 {{#if this.gradering}}
-**You have more than one employer**
+##### You have more than one employer
 
 You are working for several employers during the same period. It is only possible to combine parental benefit with work at one employer at a time. This means that it is only your period at {{this.arbeidsgiverNavn}} that will be extended.
 {{/if}}{{/if}}{{/each}}{{/if}}{{/each}}{{/gt}}
@@ -96,27 +96,27 @@ If your employer provides new information about the income you had before you st
 {{/if}}
 
 {{#if (or (eq forMyeUtbetalt "FERIE")(eq forMyeUtbetalt "JOBB"))}}
-**What happens if you receive parental benefit and salary for the same period?**
+##### What happens if you receive parental benefit and salary for the same period?
 
 If you have been paid the parental benefit at the same time as you have worked or postponed days because you have taken holidays, you have been paid an excess amount of parental benefit. This means that the payment for the next month can be reduced by the excess amount you received.
 {{/if}}
 
 {{#eq forMyeUtbetalt "GENERELL"}}
-**What happens if you receive parental benefit and salary for the same period?**
+##### What happens if you receive parental benefit and salary for the same period?
 
 If you are paid an excess amount of parental benefit, your payment for the following month may be reduced.
 {{/eq}}
 
 <br/>
 
-**You must notify any changes**<br/>
+##### You must notify any changes
 You must notify NAV immediately of any changes that might affect benefits you receive. See [nav.no/rettogplikt](https://nav.no/rettogplikt) for more detailed information.
 <br/>
 <br/>
 <br/>
 {{/gt}}
 
-**You have the right to appeal**<br/>
+##### You have the right to appeal
 You may appeal within {{klagefristUker}} weeks from the date you received the decision. You will find the relevant form and information at [nav.no/klage](https://nav.no/klage).
 <br/>
 <br/>

--- a/content/templates/innvilget-foreldrepenger/template_nb.hbs
+++ b/content/templates/innvilget-foreldrepenger/template_nb.hbs
@@ -45,7 +45,7 @@ Det er {{disponibleDager}} {{#eq disponibleDager 1}}dag{{else}}dager{{/eq}} igje
 {{~#each arbeidsforholdsliste}}
 {{#if @..first}}
 {{#if this.gradering}}
-**Du har flere arbeidsgivere**
+##### Du har flere arbeidsgivere
 
 Du jobber hos flere arbeidsgivere i samme periode. Det er kun mulig å kombinere foreldrepenger med arbeid hos én arbeidsgiver om gangen. Det betyr at det bare er perioden din hos {{this.arbeidsgiverNavn}} som blir forlenget.
 {{/if}}{{/if}}{{/each}}{{/if}}{{/each}}{{/gt}}
@@ -96,27 +96,27 @@ Hvis arbeidsgiver kommer med nye opplysninger om inntekten du hadde før du star
 {{/if}}
 
 {{#if (or (eq forMyeUtbetalt "FERIE")(eq forMyeUtbetalt "JOBB"))}}
-**Hva skjer hvis du får utbetalt foreldrepenger og lønn for samme periode?**
+##### Hva skjer hvis du får utbetalt foreldrepenger og lønn for samme periode?
 
 Hvis du har fått utbetalt foreldrepenger samtidig som du har jobbet eller utsatt dager fordi du har hatt ferie, har du fått utbetalt for mye i foreldrepenger. Det betyr at utbetalingen i neste måned kan bli redusert med det du har fått utbetalt for mye.
 {{/if}}
 
 {{#eq forMyeUtbetalt "GENERELL"}}
-**Hva skjer hvis du får utbetalt foreldrepenger og lønn for samme periode?**
+##### Hva skjer hvis du får utbetalt foreldrepenger og lønn for samme periode?
 
 Hvis du får utbetalt for mye i foreldrepenger, kan utbetalingen din bli redusert i neste måned.
 {{/eq}}
 
 <br/>
 
-**Du må melde fra om endringer**<br/>
+##### Du må melde fra om endringer
 Dersom det skjer endringer som kan ha betydning for stønaden du får utbetalt, må du straks melde fra til NAV. Du finner mer informasjon på [nav.no/rettogplikt](https://nav.no/rettogplikt).
 <br/>
 <br/>
 <br/>
 {{/gt}}
 
-**Du har rett til å klage**<br/>
+##### Du har rett til å klage
 Du kan klage innen {{klagefristUker}} uker fra den datoen du mottok vedtaket. Du finner skjema og informasjon på [nav.no/klage](https://nav.no/klage).
 <br/>
 <br/>

--- a/content/templates/innvilget-foreldrepenger/template_nn.hbs
+++ b/content/templates/innvilget-foreldrepenger/template_nn.hbs
@@ -45,7 +45,7 @@ Det er {{disponibleDager}} {{#eq disponibleDager 1}}dag{{else}}dagar{{/eq}} igje
 {{~#each arbeidsforholdsliste}}
 {{#if @..first}}
 {{#if this.gradering}}
-**Du har fleire arbeidsgivarar**
+##### Du har fleire arbeidsgivarar
 
 Du jobbar hos fleire arbeidsgivarar i same periode. Det er berre mogleg å kombinere foreldrepengar med arbeid hos éin arbeidsgivar om gongen. Det betyr at det berre er perioden din hos {{this.arbeidsgiverNavn}} som blir forlengd.
 {{/if}}{{/if}}{{/each}}{{/if}}{{/each}}{{/gt}}
@@ -96,27 +96,27 @@ Dersom arbeidsgivar kjem med nye opplysningar om inntekta du hadde før foreldre
 {{/if}}
 
 {{#if (or (eq forMyeUtbetalt "FERIE")(eq forMyeUtbetalt "JOBB"))}}
-**Kva skjer dersom du får utbetalt foreldrepengar og løn for same periode?**
+##### Kva skjer dersom du får utbetalt foreldrepengar og løn for same periode?
 
 Dersom du har fått utbetalt foreldrepengar samtidig som du har jobba eller hatt ferie, har du fått utbetalt for mykje i foreldrepengar. Det betyr at utbetalinga i neste månad kan bli redusert med det du har fått utbetalt for mykje.
 {{/if}}
 
 {{#eq forMyeUtbetalt "GENERELL"}}
-**Kva skjer dersom du får utbetalt foreldrepengar og løn for same periode?**
+##### Kva skjer dersom du får utbetalt foreldrepengar og løn for same periode?
 
 Dersom du får utbetalt for mykje i foreldrepengar, kan utbetalinga di bli redusert i neste månad.
 {{/eq}}
 
 <br/>
 
-**Du må melde frå om endringar**<br/>
+##### Du må melde frå om endringar
 Dersom det skjer endringar som kan få følgjer for stønaden du får betalt ut, må du melde frå til NAV med ein gong. Du finn meir informasjon på [nav.no/rettogplikt](https://nav.no/rettogplikt).
 <br/>
 <br/>
 <br/>
 {{/gt}}
 
-**Du har rett til å klage**<br/>
+##### Du har rett til å klage
 Du kan klage innan {{klagefristUker}} veker frå den datoen du fekk vedtaket. Du finn skjema og informasjon på [nav.no/klage](https://nav.no/klage).
 <br/>
 <br/>

--- a/content/templates/klage-avvist/template_en.hbs
+++ b/content/templates/klage-avvist/template_en.hbs
@@ -52,7 +52,7 @@ Vedtaket er gjort etter {{lovhjemler}}.
 
 <br/>
 
-**Du har rett til å klage**<br/>
+##### Du har rett til å klage
 Du kan klage innen {{klagefristUker}} uker fra den datoen du mottok vedtaket. Du finner skjema og informasjon på [nav.no/klage](https://nav.no/klage).
 <br/>
 <br/>

--- a/content/templates/klage-avvist/template_nb.hbs
+++ b/content/templates/klage-avvist/template_nb.hbs
@@ -52,7 +52,7 @@ Vedtaket er gjort etter {{lovhjemler}}.
 
 <br/>
 
-**Du har rett til å klage**<br/>
+##### Du har rett til å klage
 Du kan klage innen {{klagefristUker}} uker fra den datoen du mottok vedtaket. Du finner skjema og informasjon på [nav.no/klage](https://nav.no/klage).
 <br/>
 <br/>

--- a/content/templates/klage-avvist/template_nn.hbs
+++ b/content/templates/klage-avvist/template_nn.hbs
@@ -52,7 +52,7 @@ Vedtaket er gjort etter {{lovhjemler}}.
 
 <br/>
 
-**Du har rett til å klage**<br/>
+##### Du har rett til å klage
 Du kan klage innan {{klagefristUker}} veker frå den datoen du fekk vedtaket. Du finn skjema og informasjon på [nav.no/klage](https://nav.no/klage).
 <br/>
 <br/>

--- a/content/templates/klage-hjemsendt/template_en.hbs
+++ b/content/templates/klage-hjemsendt/template_en.hbs
@@ -26,13 +26,9 @@
 {{/if}}
 
 Informasjon om saksbehandlingstid finner du på nav.no.
-<br/>
-<br/>
 
-**Dette har vi lagt vekt på i vurderingen vår**
-<br/>
+##### Dette har vi lagt vekt på i vurderingen vår
 {{felles.fritekst}}
-<br/>
 <br/>
 
 Du kan ikke klage på denne beslutningen. Dette følger av forvaltningsloven §§ 2 og 28.

--- a/content/templates/klage-hjemsendt/template_nb.hbs
+++ b/content/templates/klage-hjemsendt/template_nb.hbs
@@ -26,13 +26,9 @@
 {{/if}}
 
 Informasjon om saksbehandlingstid finner du på nav.no.
-<br/>
-<br/>
 
-**Dette har vi lagt vekt på i vurderingen vår**
-<br/>
+##### Dette har vi lagt vekt på i vurderingen vår
 {{felles.fritekst}}
-<br/>
 <br/>
 
 Du kan ikke klage på denne beslutningen. Dette følger av forvaltningsloven §§ 2 og 28.

--- a/content/templates/klage-hjemsendt/template_nn.hbs
+++ b/content/templates/klage-hjemsendt/template_nn.hbs
@@ -26,13 +26,9 @@
 {{/if}}
 
 Informasjon om saksbehandlingstid finn du på nav.no.
-<br/>
-<br/>
 
-**Dette har vi lagt vekt på i vurderinga vår**
-<br/>
+##### Dette har vi lagt vekt på i vurderinga vår
 {{felles.fritekst}}
-<br/>
 <br/>
 
 Du kan ikkje klage på denne avgjerda. Dette følgjer av forvaltningslova §§ 2 og 28.

--- a/content/templates/klage-omgjort/template_en.hbs
+++ b/content/templates/klage-omgjort/template_en.hbs
@@ -23,43 +23,31 @@ Etter at du klaget har vi vurdert saken din på nytt. Vi har kommet fram til at 
 Etter at du klaget har vi vurdert saken din på nytt. Vi har kommet fram til at vedtaket ditt må gjøres om.
 {{/eq}}
 
-**Dette har vi lagt vekt på i vurderingen vår**
-<br/>
+##### Dette har vi lagt vekt på i vurderingen vår
 {{felles.fritekst}}
 <br/>
-<br/>
 
-**Du må melde fra om endringer**
-<br/>
+##### Du må melde fra om endringer
 Dersom det skjer endringer som kan ha betydning for stønaden du får utbetalt, må du straks melde fra til NAV. Du finner mer informasjon på [nav.no/rettogplikt](https://nav.no/rettogplikt).
 
 {{#eq gjelderTilbakekreving true}}
-<br/>
 
-**Skatt**
-<br/>
+##### Skatt
 Beløpet du skal betale tilbake er redusert med den skatten som ble trukket da du fikk utbetalingen. NAV får skatten tilbake gjennom et oppgjør med Skatteetaten.
 NAV gir opplysninger til Skatteetaten. Skatteetaten vil vurdere om det er grunnlag for å endre skatteoppgjør.
-<br/>
-<br/>
 
-**Hvordan betale tilbake pengene du skylder**
-<br/>
+##### Hvordan betale tilbake pengene du skylder
 NAV Innkreving vil korrigere beløpet du skal betale tilbake. Du finner mer informasjon på [nav.no/innkreving](https://nav.no/innkreving).
 {{/eq}}
 
-{{#eq felles.behandlesAvKA true}}
 <br/>
 
-**Du har rett til å anke**
-<br/>
+{{#eq felles.behandlesAvKA true}}
+##### Du har rett til å anke
 Du kan anke vedtaket til Trygderetten. Fristen er {{klagefristUker}} uker fra den datoen vedtaket kom fram til deg.
 Klagerettighetene dine og skjema for klage/anke finner du på [nav.no/klage](https://nav.no/klage).
 {{else}}
-<br/>
-
-**Du har rett til å klage**
-<br/>
+##### Du har rett til å klage
 Du kan klage innen {{klagefristUker}} uker fra den datoen du mottok vedtaket. Du finner skjema og informasjon på [nav.no/klage](https://nav.no/klage).
 {{#eq gjelderTilbakekreving true}}
 Du må som hovedregel begynne å betale beløpet tilbake, selv om du klager på dette vedtaket. Dette følger av forvaltningsloven § 42. Vi vil betale tilbake pengene du har betalt inn, om du får vedtak om at du ikke trengte å betale tilbake hele eller deler av beløpet du skyldte.

--- a/content/templates/klage-omgjort/template_nb.hbs
+++ b/content/templates/klage-omgjort/template_nb.hbs
@@ -23,43 +23,31 @@ Etter at du klaget har vi vurdert saken din på nytt. Vi har kommet fram til at 
 Etter at du klaget har vi vurdert saken din på nytt. Vi har kommet fram til at vedtaket ditt må gjøres om.
 {{/eq}}
 
-**Dette har vi lagt vekt på i vurderingen vår**
-<br/>
+##### Dette har vi lagt vekt på i vurderingen vår
 {{felles.fritekst}}
 <br/>
-<br/>
 
-**Du må melde fra om endringer**
-<br/>
+##### Du må melde fra om endringer
 Dersom det skjer endringer som kan ha betydning for stønaden du får utbetalt, må du straks melde fra til NAV. Du finner mer informasjon på [nav.no/rettogplikt](https://nav.no/rettogplikt).
 
 {{#eq gjelderTilbakekreving true}}
-<br/>
 
-**Skatt**
-<br/>
+##### Skatt
 Beløpet du skal betale tilbake er redusert med den skatten som ble trukket da du fikk utbetalingen. NAV får skatten tilbake gjennom et oppgjør med Skatteetaten.
 NAV gir opplysninger til Skatteetaten. Skatteetaten vil vurdere om det er grunnlag for å endre skatteoppgjør.
-<br/>
-<br/>
 
-**Hvordan betale tilbake pengene du skylder**
-<br/>
+##### Hvordan betale tilbake pengene du skylder
 NAV Innkreving vil korrigere beløpet du skal betale tilbake. Du finner mer informasjon på [nav.no/innkreving](https://nav.no/innkreving).
 {{/eq}}
 
-{{#eq felles.behandlesAvKA true}}
 <br/>
 
-**Du har rett til å anke**
-<br/>
+{{#eq felles.behandlesAvKA true}}
+##### Du har rett til å anke
 Du kan anke vedtaket til Trygderetten. Fristen er {{klagefristUker}} uker fra den datoen vedtaket kom fram til deg.
 Klagerettighetene dine og skjema for klage/anke finner du på [nav.no/klage](https://nav.no/klage).
 {{else}}
-<br/>
-
-**Du har rett til å klage**
-<br/>
+##### Du har rett til å klage
 Du kan klage innen {{klagefristUker}} uker fra den datoen du mottok vedtaket. Du finner skjema og informasjon på [nav.no/klage](https://nav.no/klage).
 {{#eq gjelderTilbakekreving true}}
 Du må som hovedregel begynne å betale beløpet tilbake, selv om du klager på dette vedtaket. Dette følger av forvaltningsloven § 42. Vi vil betale tilbake pengene du har betalt inn, om du får vedtak om at du ikke trengte å betale tilbake hele eller deler av beløpet du skyldte.

--- a/content/templates/klage-omgjort/template_nn.hbs
+++ b/content/templates/klage-omgjort/template_nn.hbs
@@ -23,43 +23,31 @@ Etter at du klaga, har vi vurdert saka di på nytt. Vi har kome fram til at vedt
 Etter at du klaga, har vi vurdert saka di på nytt. Vi har kome fram til at vedtaket ditt må gjerast om.
 {{/eq}}
 
-**Dette har vi lagt vekt på i vurderinga vår**
-<br/>
+##### Dette har vi lagt vekt på i vurderinga vår
 {{felles.fritekst}}
 <br/>
-<br/>
 
-**Du må melde frå om endringar**
-<br/>
+##### Du må melde frå om endringar
 Dersom det skjer endringar som kan få følgjer for stønaden du får betalt ut, må du melde frå til NAV med ein gong. Du finn meir informasjon på [nav.no/rettogplikt](https://nav.no/rettogplikt).
 
 {{#eq gjelderTilbakekreving true}}
-<br/>
 
-**Skatt**
-<br/>
+##### Skatt
 Beløpet du skal betale tilbake, er redusert med den skatten som blei trekt då du fekk utbetalinga. NAV får skatten tilbake gjennom eit oppgjer med Skatteetaten.
 NAV gjev opplysningar til Skatteetaten. Skatteetaten vil vurdere om det er grunnlag for å endre skatteoppgjer.
-<br/>
-<br/>
 
-**Korleis betale tilbake pengane du skuldar**
-<br/>
+##### Korleis betale tilbake pengane du skuldar
 NAV Innkrevjing vil korrigere beløpet du skal betale tilbake. Du finn meir informasjon på [nav.no/innkreving](https://nav.no/innkreving).
 {{/eq}}
 
-{{#eq felles.behandlesAvKA true}}
 <br/>
 
-**Du har rett til å anke**
-<br/>
+{{#eq felles.behandlesAvKA true}}
+##### Du har rett til å anke
 Du kan anke vedtaket til Trygderetten. Fristen er {{klagefristUker}} veker frå den datoen vedtaket kom fram til deg.
 Klagerettane dine og skjema for klage/anke finn du på [nav.no/klage](https://nav.no/klage).
 {{else}}
-<br/>
-
-**Du har rett til å klage**
-<br/>
+##### Du har rett til å klage
 Du kan klage innan {{klagefristUker}} veker frå den datoen du fekk vedtaket. Du finn skjema og informasjon på [nav.no/klage](https://nav.no/klage).
 {{#eq gjelderTilbakekreving true}}
 Du må som hovudregel begynne å betale beløpet tilbake sjølv om du klagar på dette vedtaket. Dette følgjer av forvaltningslova § 42. Vi vil betale tilbake pengane du har betalt inn, om du får vedtak om at du ikkje trong å betale tilbake heile eller delar av beløpet du skulda.

--- a/content/templates/klage-oversendt/template_en.hbs
+++ b/content/templates/klage-oversendt/template_en.hbs
@@ -14,13 +14,9 @@
 {{/if}}
 
 Informasjon om saksbehandlingstid finner du på nav.no.
-<br/>
-<br/>
 
-**Dette har vi lagt vekt på i vurderingen vår**
-<br/>
+##### Dette har vi lagt vekt på i vurderingen vår
 {{felles.fritekst}}
-<br/>
 <br/>
 
 Har du nye opplysninger eller ønsker å uttale deg, kan du sende dette via [nav.no/klage](https://nav.no/klage). Velg NAV-enhet: NAV Klageinstans Midt-Norge.

--- a/content/templates/klage-oversendt/template_nb.hbs
+++ b/content/templates/klage-oversendt/template_nb.hbs
@@ -14,13 +14,9 @@
 {{/if}}
 
 Informasjon om saksbehandlingstid finner du på nav.no.
-<br/>
-<br/>
 
-**Dette har vi lagt vekt på i vurderingen vår**
-<br/>
+##### Dette har vi lagt vekt på i vurderingen vår
 {{felles.fritekst}}
-<br/>
 <br/>
 
 Har du nye opplysninger eller ønsker å uttale deg, kan du sende dette via [nav.no/klage](https://nav.no/klage). Velg NAV-enhet: NAV Klageinstans Midt-Norge.

--- a/content/templates/klage-oversendt/template_nn.hbs
+++ b/content/templates/klage-oversendt/template_nn.hbs
@@ -14,13 +14,9 @@
 {{/if}}
 
 Informasjon om saksbehandlingstid finn du på nav.no.
-<br/>
-<br/>
 
-**Dette har vi lagt vekt på i vurderinga vår**
-<br/>
+##### Dette har vi lagt vekt på i vurderinga vår
 {{felles.fritekst}}
-<br/>
 <br/>
 
 Har du nye opplysningar eller ønskjer å uttale deg, kan du sende dette via [nav.no/klage](https://nav.no/klage). Vel NAV-eining: NAV Klageinstans Midt-Noreg.

--- a/content/templates/klage-stadfestet/template_en.hbs
+++ b/content/templates/klage-stadfestet/template_en.hbs
@@ -16,16 +16,12 @@ Vi er enige i avgjørelsen om at du ikke har rett til engangsstønad. Derfor har
 {{else}}
 Vi er enige i avgjørelsen til NAV Familie- og pensjonsytelser. Derfor har vi ikke endret vedtaket du klaget på.
 {{/eq}}
-<br/>
 
-**Dette har vi lagt vekt på i vurderingen vår**
-<br/>
+##### Dette har vi lagt vekt på i vurderingen vår
 {{felles.fritekst}}
 <br/>
-<br/>
 
-**Du har rett til å anke**
-<br/>
+##### Du har rett til å anke
 Du kan anke vedtaket til Trygderetten. Fristen er {{klagefristUker}} uker fra den datoen vedtaket kom fram til deg.
 Klagerettighetene dine og skjema for klage/anke finner du på [nav.no/klage](https://nav.no/klage).
 

--- a/content/templates/klage-stadfestet/template_nb.hbs
+++ b/content/templates/klage-stadfestet/template_nb.hbs
@@ -16,16 +16,12 @@ Vi er enige i avgjørelsen om at du ikke har rett til engangsstønad. Derfor har
 {{else}}
 Vi er enige i avgjørelsen til NAV Familie- og pensjonsytelser. Derfor har vi ikke endret vedtaket du klaget på.
 {{/eq}}
-<br/>
 
-**Dette har vi lagt vekt på i vurderingen vår**
-<br/>
+##### Dette har vi lagt vekt på i vurderingen vår
 {{felles.fritekst}}
 <br/>
-<br/>
 
-**Du har rett til å anke**
-<br/>
+##### Du har rett til å anke
 Du kan anke vedtaket til Trygderetten. Fristen er {{klagefristUker}} uker fra den datoen vedtaket kom fram til deg.
 Klagerettighetene dine og skjema for klage/anke finner du på [nav.no/klage](https://nav.no/klage).
 

--- a/content/templates/klage-stadfestet/template_nn.hbs
+++ b/content/templates/klage-stadfestet/template_nn.hbs
@@ -16,16 +16,12 @@ Vi er samde i avgjerda om at du ikkje har rett til eingongsstønad. Derfor har v
 {{else}}
 Vi er samde i avgjerda til NAV Familie- og pensjonsytelser. Derfor har vi ikkje endra vedtaket du klaga på.
 {{/eq}}
-<br/>
 
-**Dette har vi lagt vekt på i vurderinga vår**
-<br/>
+##### Dette har vi lagt vekt på i vurderinga vår
 {{felles.fritekst}}
 <br/>
-<br/>
 
-**Du har rett til å anke**
-<br/>
+##### Du har rett til å anke
 Du kan anke vedtaket til Trygderetten. Fristen er {{klagefristUker}} veker frå den datoen vedtaket kom fram til deg.
 Klagerettane dine og skjema for klage/anke finn du på [nav.no/klage](https://nav.no/klage).
 

--- a/content/templates/varsel-revurdering/template_en.hbs
+++ b/content/templates/varsel-revurdering/template_en.hbs
@@ -84,10 +84,8 @@ Du kan søke om å endre perioden din på [nav.no](https://nav.no/). Ønsker du 
 
 Your duty to give information is according to sections 21‑3 og 21‑4 of the National Insurance Act.
 <br/>
-<br/>
 
-**The decision about your {{> ytelse_navn_en}} can be reversed**
-<br/>
+##### The decision about your {{> ytelse_navn_en}} can be reversed
 We will consider your case again after the deadline has been reached. If you are not entitled to the {{> ytelse_navn_en}}, you can be asked to repay the money back.
 
 You can send us information at [nav.no/ettersendelser](https://nav.no/ettersendelser).

--- a/content/templates/varsel-revurdering/template_nb.hbs
+++ b/content/templates/varsel-revurdering/template_nb.hbs
@@ -83,10 +83,8 @@ Du kan søke om å endre perioden din på [nav.no](https://nav.no/). Ønsker du 
 
 Opplysningsplikten går fram av folketrygdloven §§ 21-3 og 21-4.
 <br/>
-<br/>
 
-**Vedtaket ditt om {{> ytelse_navn_nb}} kan bli omgjort**
-<br/>
+##### Vedtaket ditt om {{> ytelse_navn_nb}} kan bli omgjort
 Vi vil vurdere saken din på nytt når fristen er gått ut. Dersom du ikke har hatt rett til {{> ytelse_navn_nb}}, kan du bli nødt til å betale tilbake pengene.
 
 Du sender dokumentasjonen til oss på [nav.no/ettersendelser](https://nav.no/ettersendelser).

--- a/content/templates/varsel-revurdering/template_nn.hbs
+++ b/content/templates/varsel-revurdering/template_nn.hbs
@@ -83,10 +83,8 @@ Du kan søkje om å endre perioden din på [nav.no](https://nav.no/). Ønskjer d
 
 Opplysningsplikta går fram av folketrygdlova §§ 21-3 og 21-4.
 <br/>
-<br/>
 
-**Vedtaket ditt om {{> ytelse_navn_nn}} kan bli gjort om**
-<br/>
+##### Vedtaket ditt om {{> ytelse_navn_nn}} kan bli gjort om
 Vi vil vurdere saka di på nytt når fristen er gått ut. Dersom du ikkje har hatt rett til {{> ytelse_navn_nn}}, kan du bli nøydd til å betale tilbake pengane.
 
 Du sender dokumentasjonen til oss på [nav.no/ettersendelser](https://nav.no/ettersendelser).

--- a/src/test/resources/expected/engangsstonad-avslag/engangsstonad-avslag-fb_nb.txt
+++ b/src/test/resources/expected/engangsstonad-avslag/engangsstonad-avslag-fb_nb.txt
@@ -24,19 +24,19 @@ Vedtaket er gjort etter folketrygdloven § 22-13.
 
 <br/>
 
-**Du har rett til å klage**<br/>
+##### Du har rett til å klage
 Du kan klage innen 6 uker fra den datoen du mottok vedtaket. Du finner skjema og informasjon på [nav.no/klage](https://nav.no/klage).
 <br/>
 <br/>
 <br/>
-**Du har rett til innsyn**<br/>
+##### Du har rett til innsyn
 På [nav.no/dittnav](https://nav.no/dittnav) kan du se dokumentene i saken din.
 <br/>
 <br/>
 <br/>
 <div style="break-inside: avoid; page-break-inside: avoid">
 
-**Har du spørsmål?**<br/>
+##### Har du spørsmål?
 Du finner nyttig informasjon på [nav.no/familie](https://nav.no/familie).
 <br/>
 <br/>

--- a/src/test/resources/expected/engangsstonad-avslag/engangsstonad-avslag-rv_nb.txt
+++ b/src/test/resources/expected/engangsstonad-avslag/engangsstonad-avslag-rv_nb.txt
@@ -27,19 +27,19 @@ Vedtaket er gjort etter folketrygdloven § 22-13.
 
 <br/>
 
-**Du har rett til å klage**<br/>
+##### Du har rett til å klage
 Du kan klage innen 6 uker fra den datoen du mottok vedtaket. Du finner skjema og informasjon på [nav.no/klage](https://nav.no/klage).
 <br/>
 <br/>
 <br/>
-**Du har rett til innsyn**<br/>
+##### Du har rett til innsyn
 På [nav.no/dittnav](https://nav.no/dittnav) kan du se dokumentene i saken din.
 <br/>
 <br/>
 <br/>
 <div style="break-inside: avoid; page-break-inside: avoid">
 
-**Har du spørsmål?**<br/>
+##### Har du spørsmål?
 Du finner nyttig informasjon på [nav.no/familie](https://nav.no/familie).
 <br/>
 <br/>

--- a/src/test/resources/expected/engangsstonad-innvilgelse/engangsstonad-innvilgelse-endretSats_nb.txt
+++ b/src/test/resources/expected/engangsstonad-innvilgelse/engangsstonad-innvilgelse-endretSats_nb.txt
@@ -24,19 +24,19 @@ Vedtaket er gjort etter folketrygdloven § 14-17.<br/>
 
 <br/>
 
-**Du har rett til å klage**<br/>
+##### Du har rett til å klage
 Du kan klage innen 6 uker fra den datoen du mottok vedtaket. Du finner skjema og informasjon på [nav.no/klage](https://nav.no/klage).
 <br/>
 <br/>
 <br/>
-**Du har rett til innsyn**<br/>
+##### Du har rett til innsyn
 På [nav.no/dittnav](https://nav.no/dittnav) kan du se dokumentene i saken din.
 <br/>
 <br/>
 <br/>
 <div style="break-inside: avoid; page-break-inside: avoid">
 
-**Har du spørsmål?**<br/>
+##### Har du spørsmål?
 Du finner nyttig informasjon på [nav.no/familie](https://nav.no/familie).
 <br/>
 <br/>
@@ -51,6 +51,6 @@ Vedtaket har blitt automatisk saksbehandlet av vårt fagsystem. Vedtaksbrevet er
 
 <br/><br/>
 
-**Dette er en kopi, orginal er sendt til verge**.
+##### Dette er en kopi, orginal er sendt til verge.
 
 </div>

--- a/src/test/resources/expected/engangsstonad-innvilgelse/engangsstonad-innvilgelse-medhold_nb.txt
+++ b/src/test/resources/expected/engangsstonad-innvilgelse/engangsstonad-innvilgelse-medhold_nb.txt
@@ -24,19 +24,19 @@ Vedtaket er gjort etter folketrygdloven § 14-17.<br/>
 
 <br/>
 
-**Du har rett til å klage**<br/>
+##### Du har rett til å klage
 Du kan klage innen 6 uker fra den datoen du mottok vedtaket. Du finner skjema og informasjon på [nav.no/klage](https://nav.no/klage).
 <br/>
 <br/>
 <br/>
-**Du har rett til innsyn**<br/>
+##### Du har rett til innsyn
 På [nav.no/dittnav](https://nav.no/dittnav) kan du se dokumentene i saken din.
 <br/>
 <br/>
 <br/>
 <div style="break-inside: avoid; page-break-inside: avoid">
 
-**Har du spørsmål?**<br/>
+##### Har du spørsmål?
 Du finner nyttig informasjon på [nav.no/familie](https://nav.no/familie).
 <br/>
 <br/>

--- a/src/test/resources/expected/engangsstonad-innvilgelse/engangsstonad-innvilgelse_en.txt
+++ b/src/test/resources/expected/engangsstonad-innvilgelse/engangsstonad-innvilgelse_en.txt
@@ -24,19 +24,19 @@ The decision has been made pursuant to section 14-17 of the National Insurance A
 
 <br/>
 
-**You have the right to appeal**<br/>
+##### You have the right to appeal
 You may appeal within 6 weeks from the date you received the decision. You will find the relevant form and information at [nav.no/klage](https://nav.no/klage).
 <br/>
 <br/>
 <br/>
-**You have right of access**<br/>
+##### You have right of access
 Go to [nav.no/dittnav](https://nav.no/dittnav) to see the documents in your case.
 <br/>
 <br/>
 <br/>
 <div style="break-inside: avoid; page-break-inside: avoid">
 
-**Do you have questions?**<br/>
+##### Do you have questions?
 You will find useful information at [nav.no/familie](https://nav.no/familie).
 <br/>
 <br/>
@@ -51,6 +51,6 @@ This case has been electronically processed by our administration system, which 
 
 <br/><br/>
 
-**This is a copy, the orginal has been sent to the guardian**.
+##### This is a copy, the orginal has been sent to the guardian.
 
 </div>

--- a/src/test/resources/expected/engangsstonad-innvilgelse/engangsstonad-innvilgelse_nb.txt
+++ b/src/test/resources/expected/engangsstonad-innvilgelse/engangsstonad-innvilgelse_nb.txt
@@ -24,19 +24,19 @@ Vedtaket er gjort etter folketrygdloven § 14-17.<br/>
 
 <br/>
 
-**Du har rett til å klage**<br/>
+##### Du har rett til å klage
 Du kan klage innen 6 uker fra den datoen du mottok vedtaket. Du finner skjema og informasjon på [nav.no/klage](https://nav.no/klage).
 <br/>
 <br/>
 <br/>
-**Du har rett til innsyn**<br/>
+##### Du har rett til innsyn
 På [nav.no/dittnav](https://nav.no/dittnav) kan du se dokumentene i saken din.
 <br/>
 <br/>
 <br/>
 <div style="break-inside: avoid; page-break-inside: avoid">
 
-**Har du spørsmål?**<br/>
+##### Har du spørsmål?
 Du finner nyttig informasjon på [nav.no/familie](https://nav.no/familie).
 <br/>
 <br/>
@@ -51,7 +51,7 @@ Vedtaket har blitt automatisk saksbehandlet av vårt fagsystem. Vedtaksbrevet er
 
 <br/><br/>
 
-**Dette er en kopi, orginal er sendt til verge**.
+##### Dette er en kopi, orginal er sendt til verge.
 
 </div>
 

--- a/src/test/resources/expected/engangsstonad-innvilgelse/engangsstonad-innvilgelse_nn.txt
+++ b/src/test/resources/expected/engangsstonad-innvilgelse/engangsstonad-innvilgelse_nn.txt
@@ -24,19 +24,19 @@ Vedtaket er gjort etter folketrygdlova § 14-17.<br/>
 
 <br/>
 
-**Du har rett til å klage**<br/>
+##### Du har rett til å klage
 Du kan klage innan 6 veker frå den datoen du fekk vedtaket. Du finn skjema og informasjon på [nav.no/klage](https://nav.no/klage).
 <br/>
 <br/>
 <br/>
-**Du har rett til innsyn**<br/>
+##### Du har rett til innsyn
 På [nav.no/dittnav](https://nav.no/dittnav) kan du sjå dokumenta i saka di.
 <br/>
 <br/>
 <br/>
 <div style="break-inside: avoid; page-break-inside: avoid">
 
-**Har du spørsmål?**<br/>
+##### Har du spørsmål?
 Du finn nyttig informasjon på [nav.no/familie](https://nav.no/familie).
 <br/>
 <br/>
@@ -51,7 +51,7 @@ Vedtaket har blitt automatisk saksbehandla av fagsystemet vårt. Det er derfor i
 
 <br/><br/>
 
-**Dette er ein kopi, orginal er sendt til verje**.
+##### Dette er ein kopi, orginal er sendt til verje.
 
 </div>
 

--- a/src/test/resources/expected/foreldrepenger-annullert/foreldrepenger-annullert_en.txt
+++ b/src/test/resources/expected/foreldrepenger-annullert/foreldrepenger-annullert_en.txt
@@ -18,19 +18,18 @@ You are not withdrawing your parental benefit before 1. april 2022.
 Your application for parental benefit from and including 1. april 2022 can not be processed before 1. mars 2021 because parental benefit should be calculated based on the income you have when you start your withdrawal. It must also be considered whether you have earned the right to parental benefits when your period starts. You can read more about this at [nav.no/foreldrepenger](https://nav.no/foreldrepenger).
 When there are 4 weeks left until you are to withdraw your parental benefit, your employer must submit a new income report.
 The decision has been made pursuant to section 14-6, 14-7, 14-9, 14-10, 14-11 and 14-12 of the National Insurance Act.
-<br/>
-**You have the right to appeal**<br/>
+##### You have the right to appeal
 You may appeal within 6 weeks from the date you received the decision. You will find the relevant form and information at [nav.no/klage](https://nav.no/klage).
 <br/>
 <br/>
 <br/>
-**You have right of access**<br/>
+##### You have right of access
 Go to [nav.no/dittnav](https://nav.no/dittnav) to see the documents in your case.
 <br/>
 <br/>
 <br/>
 <div style="break-inside: avoid; page-break-inside: avoid">
-**Do you have questions?**<br/>
+##### Do you have questions?
 You will find useful information at [nav.no/familie](https://nav.no/familie).
 <br/>
 <br/>

--- a/src/test/resources/expected/foreldrepenger-annullert/foreldrepenger-annullert_nb.txt
+++ b/src/test/resources/expected/foreldrepenger-annullert/foreldrepenger-annullert_nb.txt
@@ -18,19 +18,18 @@ Du tar ikke ut foreldrepenger før 1. april 2022.
 Søknaden din om foreldrepenger fra og med 1. april 2022 kan ikke behandles før 1. mars 2021 fordi foreldrepenger skal beregnes ut fra den inntekten du har når du starter uttaket ditt. Det må også vurderes om du har tjent opp rett til foreldrepenger når perioden din starter. Les mer om dette på [nav.no/foreldrepenger](https://nav.no/foreldrepenger).
 Når det er 4 uker igjen til du skal ta ut foreldrepenger, må arbeidsgiveren din sende inn ny inntektsmelding.
 Vedtaket er gjort etter folketrygdloven §§ 14-6, 14-7, 14-9, 14-10, 14-11 og 14-12.
-<br/>
-**Du har rett til å klage**<br/>
+##### Du har rett til å klage
 Du kan klage innen 6 uker fra den datoen du mottok vedtaket. Du finner skjema og informasjon på [nav.no/klage](https://nav.no/klage).
 <br/>
 <br/>
 <br/>
-**Du har rett til innsyn**<br/>
+##### Du har rett til innsyn
 På [nav.no/dittnav](https://nav.no/dittnav) kan du se dokumentene i saken din.
 <br/>
 <br/>
 <br/>
 <div style="break-inside: avoid; page-break-inside: avoid">
-**Har du spørsmål?**<br/>
+##### Har du spørsmål?
 Du finner nyttig informasjon på [nav.no/familie](https://nav.no/familie).
 <br/>
 <br/>

--- a/src/test/resources/expected/foreldrepenger-annullert/foreldrepenger-annullert_nn.txt
+++ b/src/test/resources/expected/foreldrepenger-annullert/foreldrepenger-annullert_nn.txt
@@ -18,19 +18,18 @@ Du tar ikkje ut foreldrepengar før 1. april 2022.
 Søknaden din om foreldrepengar frå og med 1. april 2022 kan ikkje behandlast før 1. mars 2021 fordi foreldrepengar skal bereknast ut frå den inntekta du har når du startar uttaket ditt. Det må også vurderast om du har tent opp rett til foreldrepengar når perioden din startar. Les meir om dette på [nav.no/foreldrepenger](https://nav.no/foreldrepenger).
 Når det er 4 veker igjen til du skal ta ut foreldrepengar, må arbeidsgivaren din sende inn ny inntektsmelding.
 Vedtaket er gjort etter folketrygdlova §§ 14-6, 14-7, 14-9, 14-10, 14-11 og 14-12.
-<br/>
-**Du har rett til å klage**<br/>
+##### Du har rett til å klage
 Du kan klage innan 6 veker frå den datoen du fekk vedtaket. Du finn skjema og informasjon på [nav.no/klage](https://nav.no/klage).
 <br/>
 <br/>
 <br/>
-**Du har rett til innsyn**<br/>
+##### Du har rett til innsyn
 På [nav.no/dittnav](https://nav.no/dittnav) kan du sjå dokumenta i saka di.
 <br/>
 <br/>
 <br/>
 <div style="break-inside: avoid; page-break-inside: avoid">
-**Har du spørsmål?**<br/>
+##### Har du spørsmål?
 Du finn nyttig informasjon på [nav.no/familie](https://nav.no/familie).
 <br/>
 <br/>

--- a/src/test/resources/expected/foreldrepenger-avslag/foreldrepenger-avslag_fritekst.txt
+++ b/src/test/resources/expected/foreldrepenger-avslag/foreldrepenger-avslag_fritekst.txt
@@ -19,7 +19,7 @@ Fødselsnummer: 300220 12345
 </p>
 
 
-**Dette har vi avslått**
+##### Dette har vi avslått
 
 FRITEKST
 
@@ -28,19 +28,19 @@ Vedtaket er gjort etter folketrygdloven § forvaltningsloven § 35.
 
 <br/>
 
-**Du har rett til å klage**<br/>
+##### Du har rett til å klage
 Du kan klage innen 6 uker fra den datoen du mottok vedtaket. Du finner skjema og informasjon på [nav.no/klage](https://nav.no/klage).
 <br/>
 <br/>
 <br/>
-**Du har rett til innsyn**<br/>
+##### Du har rett til innsyn
 På [nav.no/dittnav](https://nav.no/dittnav) kan du se dokumentene i saken din.
 <br/>
 <br/>
 <br/>
 <div style="break-inside: avoid; page-break-inside: avoid">
 
-**Har du spørsmål?**<br/>
+##### Har du spørsmål?
 Du finner nyttig informasjon på [nav.no/familie](https://nav.no/familie).
 <br/>
 <br/>

--- a/src/test/resources/expected/foreldrepenger-avslag/foreldrepenger-avslag_mange_en.txt
+++ b/src/test/resources/expected/foreldrepenger-avslag/foreldrepenger-avslag_mange_en.txt
@@ -16,7 +16,7 @@ National identity number: 300220 12345
 
 </p>
 
-**We have denied the following**
+##### We have denied the following
 
 * You are not entitled to parental benefit, because you have not had earned income or income equivalent to earned income in six of the past ten months before the start of the parental benefit period.
 
@@ -232,19 +232,19 @@ The decision has been made in accordance with the National Insurance Act Section
 
 <br/>
 
-**You have the right to appeal**<br/>
+##### You have the right to appeal
 You may appeal within 6 weeks from the date you received the decision. You will find the relevant form and information at [nav.no/klage](https://nav.no/klage).
 <br/>
 <br/>
 <br/>
-**You have right of access**<br/>
+##### You have right of access
 Go to [nav.no/dittnav](https://nav.no/dittnav) to see the documents in your case.
 <br/>
 <br/>
 <br/>
 <div style="break-inside: avoid; page-break-inside: avoid">
 
-**Do you have questions?**<br/>
+##### Do you have questions?
 You will find useful information at [nav.no/familie](https://nav.no/familie).
 <br/>
 <br/>

--- a/src/test/resources/expected/foreldrepenger-avslag/foreldrepenger-avslag_mange_nb.txt
+++ b/src/test/resources/expected/foreldrepenger-avslag/foreldrepenger-avslag_mange_nb.txt
@@ -16,7 +16,7 @@ Fødselsnummer: 300220 12345
 
 </p>
 
-**Dette har vi avslått**
+##### Dette har vi avslått
 
 * Du har ikke rett til foreldrepenger, fordi du ikke har hatt arbeidsinntekt eller inntekt som er likestilt med lønn i seks av de siste ti månedene før foreldrepengeperioden starter.
 
@@ -233,19 +233,19 @@ Vedtaket er gjort etter folketrygdloven § forvaltningsloven § 35.
 
 <br/>
 
-**Du har rett til å klage**<br/>
+##### Du har rett til å klage
 Du kan klage innen 6 uker fra den datoen du mottok vedtaket. Du finner skjema og informasjon på [nav.no/klage](https://nav.no/klage).
 <br/>
 <br/>
 <br/>
-**Du har rett til innsyn**<br/>
+##### Du har rett til innsyn
 På [nav.no/dittnav](https://nav.no/dittnav) kan du se dokumentene i saken din.
 <br/>
 <br/>
 <br/>
 <div style="break-inside: avoid; page-break-inside: avoid">
 
-**Har du spørsmål?**<br/>
+##### Har du spørsmål?
 Du finner nyttig informasjon på [nav.no/familie](https://nav.no/familie).
 <br/>
 <br/>

--- a/src/test/resources/expected/foreldrepenger-avslag/foreldrepenger-avslag_mange_nn.txt
+++ b/src/test/resources/expected/foreldrepenger-avslag/foreldrepenger-avslag_mange_nn.txt
@@ -16,7 +16,7 @@ Fødselsnummer: 300220 12345
 
 </p>
 
-**Dette har vi avslått**
+##### Dette har vi avslått
 
 * Du har ikkje rett til foreldrepengar fordi du ikkje har hatt arbeidsinntekt eller inntekt som er likestilt med lønn i seks av dei siste ti månadene før foreldrepengeperioden startar.
 
@@ -233,19 +233,19 @@ Vedtaket er gjort etter folketrygdlova § forvaltningsloven § 35.
 
 <br/>
 
-**Du har rett til å klage**<br/>
+##### Du har rett til å klage
 Du kan klage innan 6 veker frå den datoen du fekk vedtaket. Du finn skjema og informasjon på [nav.no/klage](https://nav.no/klage).
 <br/>
 <br/>
 <br/>
-**Du har rett til innsyn**<br/>
+##### Du har rett til innsyn
 På [nav.no/dittnav](https://nav.no/dittnav) kan du sjå dokumenta i saka di.
 <br/>
 <br/>
 <br/>
 <div style="break-inside: avoid; page-break-inside: avoid">
 
-**Har du spørsmål?**<br/>
+##### Har du spørsmål?
 Du finn nyttig informasjon på [nav.no/familie](https://nav.no/familie).
 <br/>
 <br/>

--- a/src/test/resources/expected/foreldrepenger-infotilannenforelder/foreldrepenger-infotilannenforelder_en.txt
+++ b/src/test/resources/expected/foreldrepenger-infotilannenforelder/foreldrepenger-infotilannenforelder_en.txt
@@ -18,13 +18,12 @@ National identity number: 300220 12345
 
 You may be entitled to parental benefit. You must apply before 10. september 2020. This is the day the other parent has the last day of parental benefit. If you do not want to start the parental benefit period immediately after 10. september 2020, you must apply to postpone the period. If you apply at a later date, you will lose the days you did not postpone.
 
-**The change of parental benefit law for children born from 1 October 2021**
+##### The change of parental benefit law for children born from 1 October 2021
 For children born from and including 1 October 2021, the parents decide when they want to take out the parental benefit. Because your child was born before 1 October 2021, you must apply before the other parent has the last day of parental benefit. You must therefore apply before 10. september 2020.
 
 <br/>
-<br/>
 
-**Do you have questions?**<br/>
+##### Do you have questions?
 You will find useful information at [nav.no/familie](https://nav.no/familie).
 <br/>
 <br/>

--- a/src/test/resources/expected/foreldrepenger-infotilannenforelder/foreldrepenger-infotilannenforelder_ikke_sammenhengende_uttak_en.txt
+++ b/src/test/resources/expected/foreldrepenger-infotilannenforelder/foreldrepenger-infotilannenforelder_ikke_sammenhengende_uttak_en.txt
@@ -18,8 +18,7 @@ Please, be aware of:
 * if a parent starts a new parental benefit period for a new child, you will lose days you have not spent
 * parental benefit must be withdrawn no later than the day before the child turns three years old
 <br/>
-<br/>
-**Do you have questions?**<br/>
+##### Do you have questions?
 You will find useful information at [nav.no/familie](https://nav.no/familie).
 <br/>
 <br/>

--- a/src/test/resources/expected/foreldrepenger-infotilannenforelder/foreldrepenger-infotilannenforelder_ikke_sammenhengende_uttak_nb.txt
+++ b/src/test/resources/expected/foreldrepenger-infotilannenforelder/foreldrepenger-infotilannenforelder_ikke_sammenhengende_uttak_nb.txt
@@ -18,8 +18,7 @@ Vi gjør oppmerksom på:
 * hvis en forelder starter ny foreldrepengeperiode for nytt barn, vil du miste dager du ikke har brukt
 * foreldrepengene må være tatt ut senest dagen før barnet fyller tre år
 <br/>
-<br/>
-**Har du spørsmål?**<br/>
+##### Har du spørsmål?
 Du finner nyttig informasjon på [nav.no/familie](https://nav.no/familie).
 <br/>
 <br/>

--- a/src/test/resources/expected/foreldrepenger-infotilannenforelder/foreldrepenger-infotilannenforelder_ikke_sammenhengende_uttak_nn.txt
+++ b/src/test/resources/expected/foreldrepenger-infotilannenforelder/foreldrepenger-infotilannenforelder_ikke_sammenhengende_uttak_nn.txt
@@ -18,8 +18,7 @@ Vær oppmerksam på:
 * dersom ein forelder startar ny foreldrepengeperiode for nytt barn, vil du miste dagar du ikkje har brukt
 * foreldrepengane må være tatt ut seinast dagen før barnet fyller tre år
 <br/>
-<br/>
-**Har du spørsmål?**<br/>
+##### Har du spørsmål?
 Du finn nyttig informasjon på [nav.no/familie](https://nav.no/familie).
 <br/>
 <br/>

--- a/src/test/resources/expected/foreldrepenger-infotilannenforelder/foreldrepenger-infotilannenforelder_nb.txt
+++ b/src/test/resources/expected/foreldrepenger-infotilannenforelder/foreldrepenger-infotilannenforelder_nb.txt
@@ -18,13 +18,12 @@ Fødselsnummer: 300220 12345
 
 Du kan ha rett til foreldrepenger. Du må søke før 10. september 2020. Dette er den dagen den andre forelderen har siste dag med foreldrepenger. Hvis du ikke ønsker å starte foreldrepengeperioden rett etter 10. september 2020, må du søke om å utsette perioden. Søker du på et senere tidspunkt, mister du de dagene du har søkt for sent.
 
-**Lovendring av foreldrepengeordningen gjelder for de som har fått barn fra og med 1. oktober 2021**
+##### Lovendring av foreldrepengeordningen gjelder for de som har fått barn fra og med 1. oktober 2021
 For de som har fått barn fra og med 1. oktober 2021 bestemmer foreldrene selv når de vil ta ut foreldrepengene. Fordi du har fått barn før 01.10.2021, må du søke innen den andre forelderen har siste dag med foreldrepenger. Du må derfor søke før 10. september 2020.
 
 <br/>
-<br/>
 
-**Har du spørsmål?**<br/>
+##### Har du spørsmål?
 Du finner nyttig informasjon på [nav.no/familie](https://nav.no/familie).
 <br/>
 <br/>

--- a/src/test/resources/expected/foreldrepenger-infotilannenforelder/foreldrepenger-infotilannenforelder_nn.txt
+++ b/src/test/resources/expected/foreldrepenger-infotilannenforelder/foreldrepenger-infotilannenforelder_nn.txt
@@ -18,14 +18,12 @@ Fødselsnummer: 300220 12345
 
 Du kan ha rett til foreldrepengar. Du må søkje før 10. september 2020. Dette er den dagen den andre forelderen har siste dag med foreldrepengar. Dersom du ikkje ynskjer å starte foreldrepengeperioden rett etter 10. september 2020, må du søkje om å utsetje perioden. Søkjer du på eit seinare tidspunkt, mister du dei dagane du har søkt for seint.
 
-**Lovendring av foreldrepengeordninga gjelder for barn du fekk frå og med 1. oktober 2021**
+##### Lovendring av foreldrepengeordninga gjelder for barn du fekk frå og med 1. oktober 2021
 For dei som fekk barn frå og med 1.oktober 2021, bestemmer foreldrane sjølve når dei vil ta ut foreldrepengane. Fordi du har fått barn før 01.10.2021, må du søkje innan den andre forelderen har siste dag med foreldrepengar. Du må derfor søkje før 10. september 2020.
 
-
-<br/>
 <br/>
 
-**Har du spørsmål?**<br/>
+##### Har du spørsmål?
 Du finn nyttig informasjon på [nav.no/familie](https://nav.no/familie).
 <br/>
 <br/>

--- a/src/test/resources/expected/foreldrepenger-infotilannenforelder/foreldrepenger-infotilannenforelder_opphold_en.txt
+++ b/src/test/resources/expected/foreldrepenger-infotilannenforelder/foreldrepenger-infotilannenforelder_opphold_en.txt
@@ -19,9 +19,8 @@ National identity number: 300220 12345
 You may be entitled to parental benefit. The other parent has stated that you will have parental benefit for a period that you have not applied for. In order for these days not to be lost, the person staying at home must apply for these days. If neither of you are going to be home, one of you must apply to postpone the period of parental benefit.
 
 <br/>
-<br/>
 
-**Do you have questions?**<br/>
+##### Do you have questions?
 You will find useful information at [nav.no/familie](https://nav.no/familie).
 <br/>
 <br/>

--- a/src/test/resources/expected/foreldrepenger-infotilannenforelder/foreldrepenger-infotilannenforelder_opphold_nb.txt
+++ b/src/test/resources/expected/foreldrepenger-infotilannenforelder/foreldrepenger-infotilannenforelder_opphold_nb.txt
@@ -19,9 +19,8 @@ Fødselsnummer: 300220 12345
 Du kan ha rett til foreldrepenger. Den andre forelderen har opplyst at du skal ha foreldrepenger i en periode som du ikke har søkt om. For at disse dagene ikke skal gå tapt må den som skal være hjemme søke om disse dagene. Hvis ingen av dere skal være hjemme må en av dere søke om utsettelse av foreldrepengene.
 
 <br/>
-<br/>
 
-**Har du spørsmål?**<br/>
+##### Har du spørsmål?
 Du finner nyttig informasjon på [nav.no/familie](https://nav.no/familie).
 <br/>
 <br/>

--- a/src/test/resources/expected/foreldrepenger-infotilannenforelder/foreldrepenger-infotilannenforelder_opphold_nn.txt
+++ b/src/test/resources/expected/foreldrepenger-infotilannenforelder/foreldrepenger-infotilannenforelder_opphold_nn.txt
@@ -19,9 +19,8 @@ Fødselsnummer: 300220 12345
 Du kan ha rett til foreldrepengar. Den andre forelderen har opplyst at du skal ha foreldrepengar i ein periode som du ikkje har søkt om. For at disse dagane ikkje skal gå tapt må den som skal vere heime søkje om desse dagane. Dersom ingen av dykk skal vere heime må ein av dykk søkje om utsetjing av foreldrepengane.
 
 <br/>
-<br/>
 
-**Har du spørsmål?**<br/>
+##### Har du spørsmål?
 Du finn nyttig informasjon på [nav.no/familie](https://nav.no/familie).
 <br/>
 <br/>

--- a/src/test/resources/expected/foreldrepenger-opphor/foreldrepenger-opphør_mange_nb.txt
+++ b/src/test/resources/expected/foreldrepenger-opphor/foreldrepenger-opphør_mange_nb.txt
@@ -13,7 +13,7 @@ Navn: Dolly Duck
 Fødselsnummer: 300220 12345
 <br/>
 </p>
-**Dette har vi avslått**
+##### Dette har vi avslått
 Du hadde ikke arbeidsinntekt eller inntekt som var likestilt med lønn i seks av de siste ti månedene før perioden med foreldrepenger startet. Derfor har du ikke rett til foreldrepenger.
 Du hadde ikke rett til foreldrepenger, fordi inntekten din var lavere enn 50000 kroner i året før skatt.
 Du hadde ikke rett til foreldrepenger fordi barna dine var fylt 15 år da du overtok omsorgen.
@@ -38,18 +38,18 @@ Vi har ikke opplysninger om at du jobbet eller hadde familie som forsørget deg 
 Du har ikke rett til foreldrepenger fra 24. mai 2021 fordi du ikke lenger er medlem i folketrygden.
 Du regnes ikke som medlem fordi du oppholdt deg mer i utlandet enn i Norge.
 Vedtaket er gjort etter folketrygdloven § 14 og forvaltningsloven § 35.
-**Du har rett til å klage**<br/>
+##### Du har rett til å klage
 Du kan klage innen 6 uker fra den datoen du mottok vedtaket. Du finner skjema og informasjon på [nav.no/klage](https://nav.no/klage).
 <br/>
 <br/>
 <br/>
-**Du har rett til innsyn**<br/>
+##### Du har rett til innsyn
 På [nav.no/dittnav](https://nav.no/dittnav) kan du se dokumentene i saken din.
 <br/>
 <br/>
 <br/>
 <div style="break-inside: avoid; page-break-inside: avoid">
-**Har du spørsmål?**<br/>
+##### Har du spørsmål?
 Du finner nyttig informasjon på [nav.no/familie](https://nav.no/familie).
 <br/>
 <br/>

--- a/src/test/resources/expected/forlenget-saksbehandlingstid/forlenget-saksbehandlingstid_es_FORLENGET_nb.txt
+++ b/src/test/resources/expected/forlenget-saksbehandlingstid/forlenget-saksbehandlingstid_es_FORLENGET_nb.txt
@@ -21,14 +21,14 @@ Vi regner med å behandle søknaden din innen 5 uker.
 
 <br/>
 
-**Du har rett til innsyn**<br/>
+##### Du har rett til innsyn
 På [nav.no/dittnav](https://nav.no/dittnav) kan du se dokumentene i saken din.
 <br/>
 <br/>
 <br/>
 <div style="break-inside: avoid; page-break-inside: avoid">
 
-**Har du spørsmål?**<br/>
+##### Har du spørsmål?
 Du finner nyttig informasjon på [nav.no/familie](https://nav.no/familie).
 <br/>
 <br/>

--- a/src/test/resources/expected/forlenget-saksbehandlingstid/forlenget-saksbehandlingstid_fp_FORLENGET_død_nb.txt
+++ b/src/test/resources/expected/forlenget-saksbehandlingstid/forlenget-saksbehandlingstid_fp_FORLENGET_død_nb.txt
@@ -21,14 +21,14 @@ Vi regner med å behandle søknaden til Dolly Duck, innen 5 uker.
 
 <br/>
 
-**Du har rett til innsyn**<br/>
+##### Du har rett til innsyn
 På [nav.no/dittnav](https://nav.no/dittnav) kan du se dokumentene i saken din.
 <br/>
 <br/>
 <br/>
 <div style="break-inside: avoid; page-break-inside: avoid">
 
-**Har du spørsmål?**<br/>
+##### Har du spørsmål?
 Du finner nyttig informasjon på [nav.no/familie](https://nav.no/familie).
 <br/>
 <br/>

--- a/src/test/resources/expected/forlenget-saksbehandlingstid/forlenget-saksbehandlingstid_fp_FORLENGET_en.txt
+++ b/src/test/resources/expected/forlenget-saksbehandlingstid/forlenget-saksbehandlingstid_fp_FORLENGET_en.txt
@@ -21,14 +21,14 @@ We expect to be able to process your application within 5 weeks.
 
 <br/>
 
-**You have right of access**<br/>
+##### You have right of access
 Go to [nav.no/dittnav](https://nav.no/dittnav) to see the documents in your case.
 <br/>
 <br/>
 <br/>
 <div style="break-inside: avoid; page-break-inside: avoid">
 
-**Do you have questions?**<br/>
+##### Do you have questions?
 You will find useful information at [nav.no/familie](https://nav.no/familie).
 <br/>
 <br/>

--- a/src/test/resources/expected/forlenget-saksbehandlingstid/forlenget-saksbehandlingstid_fp_FORLENGET_nb.txt
+++ b/src/test/resources/expected/forlenget-saksbehandlingstid/forlenget-saksbehandlingstid_fp_FORLENGET_nb.txt
@@ -21,14 +21,14 @@ Vi regner med å behandle søknaden din innen 5 uker.
 
 <br/>
 
-**Du har rett til innsyn**<br/>
+##### Du har rett til innsyn
 På [nav.no/dittnav](https://nav.no/dittnav) kan du se dokumentene i saken din.
 <br/>
 <br/>
 <br/>
 <div style="break-inside: avoid; page-break-inside: avoid">
 
-**Har du spørsmål?**<br/>
+##### Har du spørsmål?
 Du finner nyttig informasjon på [nav.no/familie](https://nav.no/familie).
 <br/>
 <br/>

--- a/src/test/resources/expected/forlenget-saksbehandlingstid/forlenget-saksbehandlingstid_fp_FORLENGET_nn.txt
+++ b/src/test/resources/expected/forlenget-saksbehandlingstid/forlenget-saksbehandlingstid_fp_FORLENGET_nn.txt
@@ -21,14 +21,14 @@ Vi reknar med å behandle søknaden din innan 5 veker.
 
 <br/>
 
-**Du har rett til innsyn**<br/>
+##### Du har rett til innsyn
 På [nav.no/dittnav](https://nav.no/dittnav) kan du sjå dokumenta i saka di.
 <br/>
 <br/>
 <br/>
 <div style="break-inside: avoid; page-break-inside: avoid">
 
-**Har du spørsmål?**<br/>
+##### Har du spørsmål?
 Du finn nyttig informasjon på [nav.no/familie](https://nav.no/familie).
 <br/>
 <br/>

--- a/src/test/resources/expected/forlenget-saksbehandlingstid/forlenget-saksbehandlingstid_fp_FORTIDLIG_nb.txt
+++ b/src/test/resources/expected/forlenget-saksbehandlingstid/forlenget-saksbehandlingstid_fp_FORTIDLIG_nb.txt
@@ -21,14 +21,14 @@ Vi kan tidligst behandle søknaden din når det er fire uker igjen til perioden 
 
 <br/>
 
-**Du har rett til innsyn**<br/>
+##### Du har rett til innsyn
 På [nav.no/dittnav](https://nav.no/dittnav) kan du se dokumentene i saken din.
 <br/>
 <br/>
 <br/>
 <div style="break-inside: avoid; page-break-inside: avoid">
 
-**Har du spørsmål?**<br/>
+##### Har du spørsmål?
 Du finner nyttig informasjon på [nav.no/familie](https://nav.no/familie).
 <br/>
 <br/>

--- a/src/test/resources/expected/forlenget-saksbehandlingstid/forlenget-saksbehandlingstid_fp_KLAGE_død_nb.txt
+++ b/src/test/resources/expected/forlenget-saksbehandlingstid/forlenget-saksbehandlingstid_fp_KLAGE_død_nb.txt
@@ -21,14 +21,14 @@ Vi regner med å behandle klagen til Dolly Duck, innen 5 uker.
 
 <br/>
 
-**Du har rett til innsyn**<br/>
+##### Du har rett til innsyn
 På [nav.no/dittnav](https://nav.no/dittnav) kan du se dokumentene i saken din.
 <br/>
 <br/>
 <br/>
 <div style="break-inside: avoid; page-break-inside: avoid">
 
-**Har du spørsmål?**<br/>
+##### Har du spørsmål?
 Du finner nyttig informasjon på [nav.no/familie](https://nav.no/familie).
 <br/>
 <br/>

--- a/src/test/resources/expected/forlenget-saksbehandlingstid/forlenget-saksbehandlingstid_fp_KLAGE_nb.txt
+++ b/src/test/resources/expected/forlenget-saksbehandlingstid/forlenget-saksbehandlingstid_fp_KLAGE_nb.txt
@@ -21,14 +21,14 @@ Vi regner med å behandle klagen din innen 5 uker.
 
 <br/>
 
-**Du har rett til innsyn**<br/>
+##### Du har rett til innsyn
 På [nav.no/dittnav](https://nav.no/dittnav) kan du se dokumentene i saken din.
 <br/>
 <br/>
 <br/>
 <div style="break-inside: avoid; page-break-inside: avoid">
 
-**Har du spørsmål?**<br/>
+##### Har du spørsmål?
 Du finner nyttig informasjon på [nav.no/familie](https://nav.no/familie).
 <br/>
 <br/>

--- a/src/test/resources/expected/forlenget-saksbehandlingstid/forlenget-saksbehandlingstid_fp_MEDLEM_nb.txt
+++ b/src/test/resources/expected/forlenget-saksbehandlingstid/forlenget-saksbehandlingstid_fp_MEDLEM_nb.txt
@@ -21,14 +21,14 @@ Fordi vi ikke har opplysninger om at du jobber i Norge, må vi vente til barnet 
 
 <br/>
 
-**Du har rett til innsyn**<br/>
+##### Du har rett til innsyn
 På [nav.no/dittnav](https://nav.no/dittnav) kan du se dokumentene i saken din.
 <br/>
 <br/>
 <br/>
 <div style="break-inside: avoid; page-break-inside: avoid">
 
-**Har du spørsmål?**<br/>
+##### Har du spørsmål?
 Du finner nyttig informasjon på [nav.no/familie](https://nav.no/familie).
 <br/>
 <br/>

--- a/src/test/resources/expected/forlenget-saksbehandlingstid/forlenget-saksbehandlingstid_svp_FORLENGET_nb.txt
+++ b/src/test/resources/expected/forlenget-saksbehandlingstid/forlenget-saksbehandlingstid_svp_FORLENGET_nb.txt
@@ -21,14 +21,14 @@ Vi regner med å behandle søknaden din innen 5 uker.
 
 <br/>
 
-**Du har rett til innsyn**<br/>
+##### Du har rett til innsyn
 På [nav.no/dittnav](https://nav.no/dittnav) kan du se dokumentene i saken din.
 <br/>
 <br/>
 <br/>
 <div style="break-inside: avoid; page-break-inside: avoid">
 
-**Har du spørsmål?**<br/>
+##### Har du spørsmål?
 Du finner nyttig informasjon på [nav.no/familie](https://nav.no/familie).
 <br/>
 <br/>

--- a/src/test/resources/expected/henleggelse/henleggelse_innsyn_nb.txt
+++ b/src/test/resources/expected/henleggelse/henleggelse_innsyn_nb.txt
@@ -18,7 +18,7 @@ Fødselsnummer: 300220 12345
 
 Vi har fått beskjed om at du trekker forespørselen om innsyn i saken, og avslutter derfor behandlingen av henvendelsen din.<br/><br/>
 
-**Har du spørsmål?**<br/>
+##### Har du spørsmål?
 Du finner nyttig informasjon på [nav.no/familie](https://nav.no/familie).
 <br/>
 <br/>

--- a/src/test/resources/expected/henleggelse/henleggelse_klage_nb.txt
+++ b/src/test/resources/expected/henleggelse/henleggelse_klage_nb.txt
@@ -18,7 +18,7 @@ Fødselsnummer: 300220 12345
 
 Vi har fått beskjed om at du trekker klagen på svangerskapspenger, og avslutter derfor klagesaken din.<br/><br/>
 
-**Har du spørsmål?**<br/>
+##### Har du spørsmål?
 Du finner nyttig informasjon på [nav.no/familie](https://nav.no/familie).
 <br/>
 <br/>

--- a/src/test/resources/expected/henleggelse/henleggelse_vanligBehandling_en.txt
+++ b/src/test/resources/expected/henleggelse/henleggelse_vanligBehandling_en.txt
@@ -18,7 +18,7 @@ National identity number: 300220 12345
 
 We have been notified that you withdraw the application for parental benefit. Your case will therefore be closed.<br/><br/>
 
-**Do you have questions?**<br/>
+##### Do you have questions?
 You will find useful information at [nav.no/familie](https://nav.no/familie).
 <br/>
 <br/>

--- a/src/test/resources/expected/henleggelse/henleggelse_vanligBehandling_nb.txt
+++ b/src/test/resources/expected/henleggelse/henleggelse_vanligBehandling_nb.txt
@@ -18,7 +18,7 @@ Fødselsnummer: 300220 12345
 
 Vi har fått beskjed om at du trekker søknaden om foreldrepenger, og avslutter derfor saken din.<br/><br/>
 
-**Har du spørsmål?**<br/>
+##### Har du spørsmål?
 Du finner nyttig informasjon på [nav.no/familie](https://nav.no/familie).
 <br/>
 <br/>

--- a/src/test/resources/expected/henleggelse/henleggelse_vanligBehandling_nn.txt
+++ b/src/test/resources/expected/henleggelse/henleggelse_vanligBehandling_nn.txt
@@ -18,7 +18,7 @@ Fødselsnummer: 300220 12345
 
 Vi har fått beskjed om at du trekkjer søknaden om foreldrepengar, og avsluttar derfor saka di.<br/><br/>
 
-**Har du spørsmål?**<br/>
+##### Har du spørsmål?
 Du finn nyttig informasjon på [nav.no/familie](https://nav.no/familie).
 <br/>
 <br/>

--- a/src/test/resources/expected/ikke-sokt/ikke-sokt_fp_nb.txt
+++ b/src/test/resources/expected/ikke-sokt/ikke-sokt_fp_nb.txt
@@ -23,14 +23,14 @@ Vi kan ikke vurdere om du har rett til foreldrepenger før du har søkt. Dette g
 
 <br/>
 
-**Du har rett til innsyn**<br/>
+##### Du har rett til innsyn
 På [nav.no/dittnav](https://nav.no/dittnav) kan du se dokumentene i saken din.
 <br/>
 <br/>
 <br/>
 <div style="break-inside: avoid; page-break-inside: avoid">
 
-**Har du spørsmål?**<br/>
+##### Har du spørsmål?
 Du finner nyttig informasjon på [nav.no/familie](https://nav.no/familie).
 <br/>
 <br/>

--- a/src/test/resources/expected/ikke-sokt/ikke-sokt_fp_nn.txt
+++ b/src/test/resources/expected/ikke-sokt/ikke-sokt_fp_nn.txt
@@ -23,14 +23,14 @@ Vi kan ikkje vurdere om du har rett til foreldrepengar før du har søkt. Dette 
 
 <br/>
 
-**Du har rett til innsyn**<br/>
+##### Du har rett til innsyn
 På [nav.no/dittnav](https://nav.no/dittnav) kan du sjå dokumenta i saka di.
 <br/>
 <br/>
 <br/>
 <div style="break-inside: avoid; page-break-inside: avoid">
 
-**Har du spørsmål?**<br/>
+##### Har du spørsmål?
 Du finn nyttig informasjon på [nav.no/familie](https://nav.no/familie).
 <br/>
 <br/>

--- a/src/test/resources/expected/ikke-sokt/ikke-sokt_svp_nb.txt
+++ b/src/test/resources/expected/ikke-sokt/ikke-sokt_svp_nb.txt
@@ -23,14 +23,14 @@ Vi kan ikke vurdere om du har rett til svangerskapspenger før du har søkt. Det
 
 <br/>
 
-**Du har rett til innsyn**<br/>
+##### Du har rett til innsyn
 På [nav.no/dittnav](https://nav.no/dittnav) kan du se dokumentene i saken din.
 <br/>
 <br/>
 <br/>
 <div style="break-inside: avoid; page-break-inside: avoid">
 
-**Har du spørsmål?**<br/>
+##### Har du spørsmål?
 Du finner nyttig informasjon på [nav.no/familie](https://nav.no/familie).
 <br/>
 <br/>

--- a/src/test/resources/expected/ikke-sokt/ikke-sokt_svp_nn.txt
+++ b/src/test/resources/expected/ikke-sokt/ikke-sokt_svp_nn.txt
@@ -23,14 +23,14 @@ Vi kan ikkje vurdere om du har rett til svangerskapspengar før du har søkt. De
 
 <br/>
 
-**Du har rett til innsyn**<br/>
+##### Du har rett til innsyn
 På [nav.no/dittnav](https://nav.no/dittnav) kan du sjå dokumenta i saka di.
 <br/>
 <br/>
 <br/>
 <div style="break-inside: avoid; page-break-inside: avoid">
 
-**Har du spørsmål?**<br/>
+##### Har du spørsmål?
 Du finn nyttig informasjon på [nav.no/familie](https://nav.no/familie).
 <br/>
 <br/>

--- a/src/test/resources/expected/ingen-endring/ingen-endring_es_en.txt
+++ b/src/test/resources/expected/ingen-endring/ingen-endring_es_en.txt
@@ -21,14 +21,14 @@ We have received the requested information, and you are still entitled to lump-s
 
 <br/>
 
-**You have right of access**<br/>
+##### You have right of access
 Go to [nav.no/dittnav](https://nav.no/dittnav) to see the documents in your case.
 <br/>
 <br/>
 <br/>
 <div style="break-inside: avoid; page-break-inside: avoid">
 
-**Do you have questions?**<br/>
+##### Do you have questions?
 You will find useful information at [nav.no/familie](https://nav.no/familie).
 <br/>
 <br/>

--- a/src/test/resources/expected/ingen-endring/ingen-endring_es_nb.txt
+++ b/src/test/resources/expected/ingen-endring/ingen-endring_es_nb.txt
@@ -21,14 +21,14 @@ Vi har fått opplysningene vi har bedt om, og du har fremdeles rett til engangss
 
 <br/>
 
-**Du har rett til innsyn**<br/>
+##### Du har rett til innsyn
 På [nav.no/dittnav](https://nav.no/dittnav) kan du se dokumentene i saken din.
 <br/>
 <br/>
 <br/>
 <div style="break-inside: avoid; page-break-inside: avoid">
 
-**Har du spørsmål?**<br/>
+##### Har du spørsmål?
 Du finner nyttig informasjon på [nav.no/familie](https://nav.no/familie).
 <br/>
 <br/>

--- a/src/test/resources/expected/ingen-endring/ingen-endring_fp_nb.txt
+++ b/src/test/resources/expected/ingen-endring/ingen-endring_fp_nb.txt
@@ -21,14 +21,14 @@ Vi har fått opplysningene vi har bedt om, og du har fremdeles rett til foreldre
 
 <br/>
 
-**Du har rett til innsyn**<br/>
+##### Du har rett til innsyn
 På [nav.no/dittnav](https://nav.no/dittnav) kan du se dokumentene i saken din.
 <br/>
 <br/>
 <br/>
 <div style="break-inside: avoid; page-break-inside: avoid">
 
-**Har du spørsmål?**<br/>
+##### Har du spørsmål?
 Du finner nyttig informasjon på [nav.no/familie](https://nav.no/familie).
 <br/>
 <br/>

--- a/src/test/resources/expected/ingen-endring/ingen-endring_fp_nn.txt
+++ b/src/test/resources/expected/ingen-endring/ingen-endring_fp_nn.txt
@@ -21,14 +21,14 @@ Vi har fått opplysningane vi har bedt om, og du har framleis rett til foreldrep
 
 <br/>
 
-**Du har rett til innsyn**<br/>
+##### Du har rett til innsyn
 På [nav.no/dittnav](https://nav.no/dittnav) kan du sjå dokumenta i saka di.
 <br/>
 <br/>
 <br/>
 <div style="break-inside: avoid; page-break-inside: avoid">
 
-**Har du spørsmål?**<br/>
+##### Har du spørsmål?
 Du finn nyttig informasjon på [nav.no/familie](https://nav.no/familie).
 <br/>
 <br/>

--- a/src/test/resources/expected/ingen-endring/ingen-endring_svp_nb.txt
+++ b/src/test/resources/expected/ingen-endring/ingen-endring_svp_nb.txt
@@ -21,14 +21,14 @@ Vi har fått opplysningene vi har bedt om, og du har fremdeles rett til svangers
 
 <br/>
 
-**Du har rett til innsyn**<br/>
+##### Du har rett til innsyn
 På [nav.no/dittnav](https://nav.no/dittnav) kan du se dokumentene i saken din.
 <br/>
 <br/>
 <br/>
 <div style="break-inside: avoid; page-break-inside: avoid">
 
-**Har du spørsmål?**<br/>
+##### Har du spørsmål?
 Du finner nyttig informasjon på [nav.no/familie](https://nav.no/familie).
 <br/>
 <br/>

--- a/src/test/resources/expected/innhente-opplysninger/innhente-opplysninger_es_fgb_død_nb.txt
+++ b/src/test/resources/expected/innhente-opplysninger/innhente-opplysninger_es_fgb_død_nb.txt
@@ -18,30 +18,28 @@ Fødselsnummer: 300220 12345
 
 Vi fikk søknad om engangsstønad fra Dolly Duck 1. april 2020, men mangler opplysninger for å kunne behandle den.
 
-**Du må sende oss**
-<br/>
+##### Du må sende oss
 Tekst
 - Attest
 - Bekreftelse
 Mer tekst
 <br/>
-
-**Søknaden kan bli avslått**
 <br/>
+##### Søknaden kan bli avslått
 Hvis vi ikke får opplysningene innen 24. mai 2020, kan søknaden bli avslått.
 
 Dette går fram av folketrygdloven § 21-3.
 <br/>
 <br/>
 <br/>
-**Du har rett til innsyn**<br/>
+##### Du har rett til innsyn
 På [nav.no/dittnav](https://nav.no/dittnav) kan du se dokumentene i saken din.
 <br/>
 <br/>
 <br/>
 <div style="break-inside: avoid; page-break-inside: avoid">
 
-**Har du spørsmål?**<br/>
+##### Har du spørsmål?
 Du finner nyttig informasjon på [nav.no/familie](https://nav.no/familie).
 <br/>
 <br/>

--- a/src/test/resources/expected/innhente-opplysninger/innhente-opplysninger_es_fgb_død_nn.txt
+++ b/src/test/resources/expected/innhente-opplysninger/innhente-opplysninger_es_fgb_død_nn.txt
@@ -18,30 +18,28 @@ Fødselsnummer: 300220 12345
 
 Vi fekk søknad om eingongsstønad frå Dolly Duck 1. april 2020, men manglar opplysningar for å kunne behandle den.
 
-**Du må sende oss**
-<br/>
+##### Du må sende oss
 Tekst
 - Attest
 - Bekreftelse
 Mer tekst
 <br/>
-
-**Søknaden kan bli avslått**
 <br/>
+##### Søknaden kan bli avslått
 Dersom vi ikkje får opplysningane innan 24. mai 2020, kan søknaden bli avslått.
 
 Dette går fram av folketrygdlova § 21-3.
 <br/>
 <br/>
 <br/>
-**Du har rett til innsyn**<br/>
+##### Du har rett til innsyn
 På [nav.no/dittnav](https://nav.no/dittnav) kan du sjå dokumenta i saka di.
 <br/>
 <br/>
 <br/>
 <div style="break-inside: avoid; page-break-inside: avoid">
 
-**Har du spørsmål?**<br/>
+##### Har du spørsmål?
 Du finn nyttig informasjon på [nav.no/familie](https://nav.no/familie).
 <br/>
 <br/>

--- a/src/test/resources/expected/innhente-opplysninger/innhente-opplysninger_es_fgb_en.txt
+++ b/src/test/resources/expected/innhente-opplysninger/innhente-opplysninger_es_fgb_en.txt
@@ -18,30 +18,28 @@ National identity number: 300220 12345
 
 We received your application concerning lump-sum grant 1. april 2020, but we need more information to process it.
 
-**You have to send us**
-<br/>
+##### You have to send us
 Tekst
 - Attest
 - Bekreftelse
 Mer tekst
 <br/>
-
-**Your application can be turned down**
 <br/>
+##### Your application can be turned down
 If you do not send us the requested documentation before 24. mai 2020, your application can be turned down.
 
 This is pursuant to section 21‑3 of the National Insurance Act.
 <br/>
 <br/>
 <br/>
-**You have right of access**<br/>
+##### You have right of access
 Go to [nav.no/dittnav](https://nav.no/dittnav) to see the documents in your case.
 <br/>
 <br/>
 <br/>
 <div style="break-inside: avoid; page-break-inside: avoid">
 
-**Do you have questions?**<br/>
+##### Do you have questions?
 You will find useful information at [nav.no/familie](https://nav.no/familie).
 <br/>
 <br/>

--- a/src/test/resources/expected/innhente-opplysninger/innhente-opplysninger_es_fgb_nb.txt
+++ b/src/test/resources/expected/innhente-opplysninger/innhente-opplysninger_es_fgb_nb.txt
@@ -18,30 +18,29 @@ Fødselsnummer: 300220 12345
 
 Vi fikk søknaden din om engangsstønad 1. april 2020, men mangler opplysninger for å kunne behandle den.
 
-**Du må sende oss**
-<br/>
+##### Du må sende oss
 Tekst
 - Attest
 - Bekreftelse
 Mer tekst
 <br/>
-
-**Søknaden kan bli avslått**
 <br/>
+
+##### Søknaden kan bli avslått
 Hvis vi ikke får opplysningene innen 24. mai 2020, kan søknaden bli avslått.
 
 Dette går fram av folketrygdloven § 21-3.
 <br/>
 <br/>
 <br/>
-**Du har rett til innsyn**<br/>
+##### Du har rett til innsyn
 På [nav.no/dittnav](https://nav.no/dittnav) kan du se dokumentene i saken din.
 <br/>
 <br/>
 <br/>
 <div style="break-inside: avoid; page-break-inside: avoid">
 
-**Har du spørsmål?**<br/>
+##### Har du spørsmål?
 Du finner nyttig informasjon på [nav.no/familie](https://nav.no/familie).
 <br/>
 <br/>

--- a/src/test/resources/expected/innhente-opplysninger/innhente-opplysninger_es_fgb_nn.txt
+++ b/src/test/resources/expected/innhente-opplysninger/innhente-opplysninger_es_fgb_nn.txt
@@ -18,30 +18,28 @@ Fødselsnummer: 300220 12345
 
 Vi fekk søknaden din om eingongsstønad 1. april 2020, men manglar opplysningar for å kunne behandle den.
 
-**Du må sende oss**
-<br/>
+##### Du må sende oss
 Tekst
 - Attest
 - Bekreftelse
 Mer tekst
 <br/>
-
-**Søknaden kan bli avslått**
 <br/>
+##### Søknaden kan bli avslått
 Dersom vi ikkje får opplysningane innan 24. mai 2020, kan søknaden bli avslått.
 
 Dette går fram av folketrygdlova § 21-3.
 <br/>
 <br/>
 <br/>
-**Du har rett til innsyn**<br/>
+##### Du har rett til innsyn
 På [nav.no/dittnav](https://nav.no/dittnav) kan du sjå dokumenta i saka di.
 <br/>
 <br/>
 <br/>
 <div style="break-inside: avoid; page-break-inside: avoid">
 
-**Har du spørsmål?**<br/>
+##### Har du spørsmål?
 Du finn nyttig informasjon på [nav.no/familie](https://nav.no/familie).
 <br/>
 <br/>

--- a/src/test/resources/expected/innhente-opplysninger/innhente-opplysninger_es_fgb_utkast.txt
+++ b/src/test/resources/expected/innhente-opplysninger/innhente-opplysninger_es_fgb_utkast.txt
@@ -19,30 +19,28 @@ Fødselsnummer: 300220 12345
 
 Vi fikk søknaden din om engangsstønad 1. april 2020, men mangler opplysninger for å kunne behandle den.
 
-**Du må sende oss**
-<br/>
+##### Du må sende oss
 Tekst
 - Attest
 - Bekreftelse
 Mer tekst
 <br/>
-
-**Søknaden kan bli avslått**
 <br/>
+##### Søknaden kan bli avslått
 Hvis vi ikke får opplysningene innen 24. mai 2020, kan søknaden bli avslått.
 
 Dette går fram av folketrygdloven § 21-3.
 <br/>
 <br/>
 <br/>
-**Du har rett til innsyn**<br/>
+##### Du har rett til innsyn
 På [nav.no/dittnav](https://nav.no/dittnav) kan du se dokumentene i saken din.
 <br/>
 <br/>
 <br/>
 <div style="break-inside: avoid; page-break-inside: avoid">
 
-**Har du spørsmål?**<br/>
+##### Har du spørsmål?
 Du finner nyttig informasjon på [nav.no/familie](https://nav.no/familie).
 <br/>
 <br/>

--- a/src/test/resources/expected/innhente-opplysninger/innhente-opplysninger_es_klage_død_nb.txt
+++ b/src/test/resources/expected/innhente-opplysninger/innhente-opplysninger_es_klage_død_nb.txt
@@ -18,30 +18,28 @@ Fødselsnummer: 300220 12345
 
 Vi fikk klage på engangsstønad fra Dolly Duck 1. april 2020, men mangler opplysninger for å kunne behandle den.
 
-**Du må sende oss**
-<br/>
+##### Du må sende oss
 Tekst
 - Attest
 - Bekreftelse
 Mer tekst
 <br/>
-
-**Søknaden kan bli avslått**
 <br/>
+##### Søknaden kan bli avslått
 Hvis du ikke sender oss dette innen 24. mai 2020, behandler vi saken med de opplysningene vi har.
 
 Dette går fram av folketrygdloven § 21-3.
 <br/>
 <br/>
 <br/>
-**Du har rett til innsyn**<br/>
+##### Du har rett til innsyn
 På [nav.no/dittnav](https://nav.no/dittnav) kan du se dokumentene i saken din.
 <br/>
 <br/>
 <br/>
 <div style="break-inside: avoid; page-break-inside: avoid">
 
-**Har du spørsmål?**<br/>
+##### Har du spørsmål?
 Du finner nyttig informasjon på [nav.no/familie](https://nav.no/familie).
 <br/>
 <br/>

--- a/src/test/resources/expected/innhente-opplysninger/innhente-opplysninger_es_klage_død_nn.txt
+++ b/src/test/resources/expected/innhente-opplysninger/innhente-opplysninger_es_klage_død_nn.txt
@@ -18,30 +18,28 @@ Fødselsnummer: 300220 12345
 
 Vi fekk klage på eingongsstønad frå Dolly Duck 1. april 2020, men manglar opplysningar for å kunne behandle den.
 
-**Du må sende oss**
-<br/>
+##### Du må sende oss
 Tekst
 - Attest
 - Bekreftelse
 Mer tekst
 <br/>
-
-**Søknaden kan bli avslått**
 <br/>
+##### Søknaden kan bli avslått
 Dersom du ikkje sender oss dette innan 24. mai 2020, behandlar vi saka di med dei opplysningane vi har.
 
 Dette går fram av folketrygdlova § 21-3.
 <br/>
 <br/>
 <br/>
-**Du har rett til innsyn**<br/>
+##### Du har rett til innsyn
 På [nav.no/dittnav](https://nav.no/dittnav) kan du sjå dokumenta i saka di.
 <br/>
 <br/>
 <br/>
 <div style="break-inside: avoid; page-break-inside: avoid">
 
-**Har du spørsmål?**<br/>
+##### Har du spørsmål?
 Du finn nyttig informasjon på [nav.no/familie](https://nav.no/familie).
 <br/>
 <br/>

--- a/src/test/resources/expected/innhente-opplysninger/innhente-opplysninger_es_klage_ka.txt
+++ b/src/test/resources/expected/innhente-opplysninger/innhente-opplysninger_es_klage_ka.txt
@@ -18,32 +18,30 @@ Fødselsnummer: 300220 12345
 
 Vi fikk klagen din på engangsstønad 1. april 2020, men mangler opplysninger for å kunne behandle den.
 
-**Du må sende oss**
-<br/>
+##### Du må sende oss
 Tekst
 - Attest
 - Bekreftelse
 Mer tekst
 <br/>
-
+<br/>
 Du sender dokumentasjonen til oss på [nav.no/klage](https://nav.no/klage). Velg NAV-enhet: NAV Klageinstans Midt-Norge.
 
-**Søknaden kan bli avslått**
-<br/>
+##### Søknaden kan bli avslått
 Hvis du ikke sender oss dette innen 24. mai 2020, behandler vi saken med de opplysningene vi har.
 
 Dette går fram av folketrygdloven § 21-3.
 <br/>
 <br/>
 <br/>
-**Du har rett til innsyn**<br/>
+##### Du har rett til innsyn
 På [nav.no/dittnav](https://nav.no/dittnav) kan du se dokumentene i saken din.
 <br/>
 <br/>
 <br/>
 <div style="break-inside: avoid; page-break-inside: avoid">
 
-**Har du spørsmål?**<br/>
+##### Har du spørsmål?
 Du finner nyttig informasjon på [nav.no/familie](https://nav.no/familie).
 <br/>
 <br/>

--- a/src/test/resources/expected/innhente-opplysninger/innhente-opplysninger_es_klage_nb.txt
+++ b/src/test/resources/expected/innhente-opplysninger/innhente-opplysninger_es_klage_nb.txt
@@ -18,30 +18,28 @@ Fødselsnummer: 300220 12345
 
 Vi fikk klagen din på engangsstønad 1. april 2020, men mangler opplysninger for å kunne behandle den.
 
-**Du må sende oss**
-<br/>
+##### Du må sende oss
 Tekst
 - Attest
 - Bekreftelse
 Mer tekst
 <br/>
-
-**Søknaden kan bli avslått**
 <br/>
+##### Søknaden kan bli avslått
 Hvis du ikke sender oss dette innen 24. mai 2020, behandler vi saken med de opplysningene vi har.
 
 Dette går fram av folketrygdloven § 21-3.
 <br/>
 <br/>
 <br/>
-**Du har rett til innsyn**<br/>
+##### Du har rett til innsyn
 På [nav.no/dittnav](https://nav.no/dittnav) kan du se dokumentene i saken din.
 <br/>
 <br/>
 <br/>
 <div style="break-inside: avoid; page-break-inside: avoid">
 
-**Har du spørsmål?**<br/>
+##### Har du spørsmål?
 Du finner nyttig informasjon på [nav.no/familie](https://nav.no/familie).
 <br/>
 <br/>

--- a/src/test/resources/expected/innhente-opplysninger/innhente-opplysninger_es_klage_nn.txt
+++ b/src/test/resources/expected/innhente-opplysninger/innhente-opplysninger_es_klage_nn.txt
@@ -18,30 +18,28 @@ Fødselsnummer: 300220 12345
 
 Vi fekk klagen din på eingongsstønad 1. april 2020, men manglar opplysningar for å kunne behandle den.
 
-**Du må sende oss**
-<br/>
+##### Du må sende oss
 Tekst
 - Attest
 - Bekreftelse
 Mer tekst
 <br/>
-
-**Søknaden kan bli avslått**
 <br/>
+##### Søknaden kan bli avslått
 Dersom du ikkje sender oss dette innan 24. mai 2020, behandlar vi saka di med dei opplysningane vi har.
 
 Dette går fram av folketrygdlova § 21-3.
 <br/>
 <br/>
 <br/>
-**Du har rett til innsyn**<br/>
+##### Du har rett til innsyn
 På [nav.no/dittnav](https://nav.no/dittnav) kan du sjå dokumenta i saka di.
 <br/>
 <br/>
 <br/>
 <div style="break-inside: avoid; page-break-inside: avoid">
 
-**Har du spørsmål?**<br/>
+##### Har du spørsmål?
 Du finn nyttig informasjon på [nav.no/familie](https://nav.no/familie).
 <br/>
 <br/>

--- a/src/test/resources/expected/innhente-opplysninger/innhente-opplysninger_es_revurdering_nb.txt
+++ b/src/test/resources/expected/innhente-opplysninger/innhente-opplysninger_es_revurdering_nb.txt
@@ -18,30 +18,28 @@ Fødselsnummer: 300220 12345
 
 Vi har fått nye opplysninger i saken om engangsstønad, men mangler dokumentasjon for å behandle den på nytt.
 
-**Du må sende oss**
-<br/>
+##### Du må sende oss
 Tekst
 - Attest
 - Bekreftelse
 Mer tekst
 <br/>
-
-**Søknaden kan bli avslått**
 <br/>
+##### Søknaden kan bli avslått
 Hvis du ikke sender oss dette innen 24. mai 2020, behandler vi saken med de opplysningene vi har.
 
 Dette går fram av folketrygdloven § 21-3.
 <br/>
 <br/>
 <br/>
-**Du har rett til innsyn**<br/>
+##### Du har rett til innsyn
 På [nav.no/dittnav](https://nav.no/dittnav) kan du se dokumentene i saken din.
 <br/>
 <br/>
 <br/>
 <div style="break-inside: avoid; page-break-inside: avoid">
 
-**Har du spørsmål?**<br/>
+##### Har du spørsmål?
 Du finner nyttig informasjon på [nav.no/familie](https://nav.no/familie).
 <br/>
 <br/>

--- a/src/test/resources/expected/innhente-opplysninger/innhente-opplysninger_es_revurdering_nn.txt
+++ b/src/test/resources/expected/innhente-opplysninger/innhente-opplysninger_es_revurdering_nn.txt
@@ -18,30 +18,28 @@ Fødselsnummer: 300220 12345
 
 Vi har fått nye opplysningar i saka om eingongsstønad, men manglar dokumentasjon for å kunne behandle den på nytt.
 
-**Du må sende oss**
-<br/>
+##### Du må sende oss
 Tekst
 - Attest
 - Bekreftelse
 Mer tekst
 <br/>
-
-**Søknaden kan bli avslått**
 <br/>
+##### Søknaden kan bli avslått
 Dersom du ikkje sender oss dette innan 24. mai 2020, behandlar vi saka di med dei opplysningane vi har.
 
 Dette går fram av folketrygdlova § 21-3.
 <br/>
 <br/>
 <br/>
-**Du har rett til innsyn**<br/>
+##### Du har rett til innsyn
 På [nav.no/dittnav](https://nav.no/dittnav) kan du sjå dokumenta i saka di.
 <br/>
 <br/>
 <br/>
 <div style="break-inside: avoid; page-break-inside: avoid">
 
-**Har du spørsmål?**<br/>
+##### Har du spørsmål?
 Du finn nyttig informasjon på [nav.no/familie](https://nav.no/familie).
 <br/>
 <br/>

--- a/src/test/resources/expected/innhente-opplysninger/innhente-opplysninger_fp_endringssøknad_nb.txt
+++ b/src/test/resources/expected/innhente-opplysninger/innhente-opplysninger_fp_endringssøknad_nb.txt
@@ -18,30 +18,28 @@ Fødselsnummer: 300220 12345
 
 Vi fikk søknaden din om å endre foreldrepengeperioden 1. april 2020, men mangler opplysninger for å kunne behandle den.
 
-**Du må sende oss**
-<br/>
+##### Du må sende oss
 Tekst
 - Attest
 - Bekreftelse
 Mer tekst
 <br/>
-
-**Søknaden kan bli avslått**
 <br/>
+##### Søknaden kan bli avslått
 Hvis du ikke sender oss dette innen 24. mai 2020, behandler vi saken med de opplysningene vi har.
 
 Dette går fram av folketrygdloven § 21-3.
 <br/>
 <br/>
 <br/>
-**Du har rett til innsyn**<br/>
+##### Du har rett til innsyn
 På [nav.no/dittnav](https://nav.no/dittnav) kan du se dokumentene i saken din.
 <br/>
 <br/>
 <br/>
 <div style="break-inside: avoid; page-break-inside: avoid">
 
-**Har du spørsmål?**<br/>
+##### Har du spørsmål?
 Du finner nyttig informasjon på [nav.no/familie](https://nav.no/familie).
 <br/>
 <br/>

--- a/src/test/resources/expected/innhente-opplysninger/innhente-opplysninger_fp_endringssøknad_nn.txt
+++ b/src/test/resources/expected/innhente-opplysninger/innhente-opplysninger_fp_endringssøknad_nn.txt
@@ -18,30 +18,28 @@ Fødselsnummer: 300220 12345
 
 Vi fekk søknaden din om å endre foreldrepengeperioden 1. april 2020, men manglar opplysningar for å kunne behandle den.
 
-**Du må sende oss**
-<br/>
+##### Du må sende oss
 Tekst
 - Attest
 - Bekreftelse
 Mer tekst
 <br/>
-
-**Søknaden kan bli avslått**
 <br/>
+##### Søknaden kan bli avslått
 Dersom du ikkje sender oss dette innan 24. mai 2020, behandlar vi saka di med dei opplysningane vi har.
 
 Dette går fram av folketrygdlova § 21-3.
 <br/>
 <br/>
 <br/>
-**Du har rett til innsyn**<br/>
+##### Du har rett til innsyn
 På [nav.no/dittnav](https://nav.no/dittnav) kan du sjå dokumenta i saka di.
 <br/>
 <br/>
 <br/>
 <div style="break-inside: avoid; page-break-inside: avoid">
 
-**Har du spørsmål?**<br/>
+##### Har du spørsmål?
 Du finn nyttig informasjon på [nav.no/familie](https://nav.no/familie).
 <br/>
 <br/>

--- a/src/test/resources/expected/innhente-opplysninger/innhente-opplysninger_fp_fgb_nb.txt
+++ b/src/test/resources/expected/innhente-opplysninger/innhente-opplysninger_fp_fgb_nb.txt
@@ -18,30 +18,28 @@ Fødselsnummer: 300220 12345
 
 Vi fikk søknaden din om foreldrepenger 1. april 2020, men mangler opplysninger for å kunne behandle den.
 
-**Du må sende oss**
-<br/>
+##### Du må sende oss
 Tekst
 - Attest
 - Bekreftelse
 Mer tekst
 <br/>
-
-**Søknaden kan bli avslått**
 <br/>
+##### Søknaden kan bli avslått
 Hvis vi ikke får opplysningene innen 24. mai 2020, kan søknaden bli avslått.
 
 Dette går fram av folketrygdloven § 21-3.
 <br/>
 <br/>
 <br/>
-**Du har rett til innsyn**<br/>
+##### Du har rett til innsyn
 På [nav.no/dittnav](https://nav.no/dittnav) kan du se dokumentene i saken din.
 <br/>
 <br/>
 <br/>
 <div style="break-inside: avoid; page-break-inside: avoid">
 
-**Har du spørsmål?**<br/>
+##### Har du spørsmål?
 Du finner nyttig informasjon på [nav.no/familie](https://nav.no/familie).
 <br/>
 <br/>

--- a/src/test/resources/expected/innhente-opplysninger/innhente-opplysninger_fp_fgb_nn.txt
+++ b/src/test/resources/expected/innhente-opplysninger/innhente-opplysninger_fp_fgb_nn.txt
@@ -18,30 +18,28 @@ Fødselsnummer: 300220 12345
 
 Vi fekk søknaden din om foreldrepengar 1. april 2020, men manglar opplysningar for å kunne behandle den.
 
-**Du må sende oss**
-<br/>
+##### Du må sende oss
 Tekst
 - Attest
 - Bekreftelse
 Mer tekst
 <br/>
-
-**Søknaden kan bli avslått**
 <br/>
+##### Søknaden kan bli avslått
 Dersom vi ikkje får opplysningane innan 24. mai 2020, kan søknaden bli avslått.
 
 Dette går fram av folketrygdlova § 21-3.
 <br/>
 <br/>
 <br/>
-**Du har rett til innsyn**<br/>
+##### Du har rett til innsyn
 På [nav.no/dittnav](https://nav.no/dittnav) kan du sjå dokumenta i saka di.
 <br/>
 <br/>
 <br/>
 <div style="break-inside: avoid; page-break-inside: avoid">
 
-**Har du spørsmål?**<br/>
+##### Har du spørsmål?
 Du finn nyttig informasjon på [nav.no/familie](https://nav.no/familie).
 <br/>
 <br/>

--- a/src/test/resources/expected/innhente-opplysninger/innhente-opplysninger_svp_fgb_nb.txt
+++ b/src/test/resources/expected/innhente-opplysninger/innhente-opplysninger_svp_fgb_nb.txt
@@ -18,30 +18,28 @@ Fødselsnummer: 300220 12345
 
 Vi fikk søknaden din om svangerskapspenger 1. april 2020, men mangler opplysninger for å kunne behandle den.
 
-**Du må sende oss**
-<br/>
+##### Du må sende oss
 Tekst
 - Attest
 - Bekreftelse
 Mer tekst
 <br/>
-
-**Søknaden kan bli avslått**
 <br/>
+##### Søknaden kan bli avslått
 Hvis vi ikke får opplysningene innen 24. mai 2020, kan søknaden bli avslått.
 
 Dette går fram av folketrygdloven § 21-3.
 <br/>
 <br/>
 <br/>
-**Du har rett til innsyn**<br/>
+##### Du har rett til innsyn
 På [nav.no/dittnav](https://nav.no/dittnav) kan du se dokumentene i saken din.
 <br/>
 <br/>
 <br/>
 <div style="break-inside: avoid; page-break-inside: avoid">
 
-**Har du spørsmål?**<br/>
+##### Har du spørsmål?
 Du finner nyttig informasjon på [nav.no/familie](https://nav.no/familie).
 <br/>
 <br/>

--- a/src/test/resources/expected/innhente-opplysninger/innhente-opplysninger_svp_fgb_nn.txt
+++ b/src/test/resources/expected/innhente-opplysninger/innhente-opplysninger_svp_fgb_nn.txt
@@ -18,30 +18,28 @@ Fødselsnummer: 300220 12345
 
 Vi fekk søknaden din om svangerskapspengar 1. april 2020, men manglar opplysningar for å kunne behandle den.
 
-**Du må sende oss**
-<br/>
+##### Du må sende oss
 Tekst
 - Attest
 - Bekreftelse
 Mer tekst
 <br/>
-
-**Søknaden kan bli avslått**
 <br/>
+##### Søknaden kan bli avslått
 Dersom vi ikkje får opplysningane innan 24. mai 2020, kan søknaden bli avslått.
 
 Dette går fram av folketrygdlova § 21-3.
 <br/>
 <br/>
 <br/>
-**Du har rett til innsyn**<br/>
+##### Du har rett til innsyn
 På [nav.no/dittnav](https://nav.no/dittnav) kan du sjå dokumenta i saka di.
 <br/>
 <br/>
 <br/>
 <div style="break-inside: avoid; page-break-inside: avoid">
 
-**Har du spørsmål?**<br/>
+##### Har du spørsmål?
 Du finn nyttig informasjon på [nav.no/familie](https://nav.no/familie).
 <br/>
 <br/>

--- a/src/test/resources/expected/innsyn/innsyn_avvist_en.txt
+++ b/src/test/resources/expected/innsyn/innsyn_avvist_en.txt
@@ -24,14 +24,14 @@ This is pursuant to section 18 of the Public Administration Act.
 
 <br/>
 
-**You have the right to appeal**<br/>
+##### You have the right to appeal
 You may appeal within 6 weeks from the date you received the decision. You will find the relevant form and information at [nav.no/klage](https://nav.no/klage).
 
 The right to appeal regarding access is pursuant to section 21 of the Public Administration Act.
 <br/>
 <br/>
 <br/>
-**Do you have questions?**<br/>
+##### Do you have questions?
 You will find useful information at [nav.no/familie](https://nav.no/familie).
 <br/>
 <br/>

--- a/src/test/resources/expected/innsyn/innsyn_avvist_nb.txt
+++ b/src/test/resources/expected/innsyn/innsyn_avvist_nb.txt
@@ -24,14 +24,14 @@ Dette går fram av forvaltningsloven § 18.
 
 <br/>
 
-**Du har rett til å klage**<br/>
+##### Du har rett til å klage
 Du kan klage innen 6 uker fra den datoen du mottok vedtaket. Du finner skjema og informasjon på [nav.no/klage](https://nav.no/klage)
 
 Retten til å klage på innsyn går fram av forvaltningsloven § 21.
 <br/>
 <br/>
 <br/>
-**Har du spørsmål?**<br/>
+##### Har du spørsmål?
 Du finner nyttig informasjon på [nav.no/familie](https://nav.no/familie).
 <br/>
 <br/>

--- a/src/test/resources/expected/innsyn/innsyn_avvist_nn.txt
+++ b/src/test/resources/expected/innsyn/innsyn_avvist_nn.txt
@@ -24,14 +24,14 @@ Dette går fram av forvaltningslova § 18.
 
 <br/>
 
-**Du har rett til å klage**<br/>
+##### Du har rett til å klage
 Du kan klage innan 6 veker frå den datoen du fekk brevet. Du finn skjema og informasjon på [nav.no/klage](https://nav.no/klage)
 
 Retten til å klage på innsyn går fram av forvaltningslova § 21.
 <br/>
 <br/>
 <br/>
-**Har du spørsmål?**<br/>
+##### Har du spørsmål?
 Du finn nyttig informasjon på [nav.no/familie](https://nav.no/familie).
 <br/>
 <br/>

--- a/src/test/resources/expected/innsyn/innsyn_delvis_innvilget_en.txt
+++ b/src/test/resources/expected/innsyn/innsyn_delvis_innvilget_en.txt
@@ -24,14 +24,14 @@ This is pursuant to section 18 of the Public Administration Act.
 
 <br/>
 
-**You have the right to appeal**<br/>
+##### You have the right to appeal
 You may appeal within 6 weeks from the date you received the decision. You will find the relevant form and information at [nav.no/klage](https://nav.no/klage).
 
 The right to appeal regarding access is pursuant to section 21 of the Public Administration Act.
 <br/>
 <br/>
 <br/>
-**Do you have questions?**<br/>
+##### Do you have questions?
 You will find useful information at [nav.no/familie](https://nav.no/familie).
 <br/>
 <br/>

--- a/src/test/resources/expected/innsyn/innsyn_delvis_innvilget_nb.txt
+++ b/src/test/resources/expected/innsyn/innsyn_delvis_innvilget_nb.txt
@@ -24,14 +24,14 @@ Dette går fram av forvaltningsloven § 18.
 
 <br/>
 
-**Du har rett til å klage**<br/>
+##### Du har rett til å klage
 Du kan klage innen 6 uker fra den datoen du mottok vedtaket. Du finner skjema og informasjon på [nav.no/klage](https://nav.no/klage)
 
 Retten til å klage på innsyn går fram av forvaltningsloven § 21.
 <br/>
 <br/>
 <br/>
-**Har du spørsmål?**<br/>
+##### Har du spørsmål?
 Du finner nyttig informasjon på [nav.no/familie](https://nav.no/familie).
 <br/>
 <br/>

--- a/src/test/resources/expected/innsyn/innsyn_delvis_innvilget_nn.txt
+++ b/src/test/resources/expected/innsyn/innsyn_delvis_innvilget_nn.txt
@@ -24,14 +24,14 @@ Dette går fram av forvaltningslova § 18.
 
 <br/>
 
-**Du har rett til å klage**<br/>
+##### Du har rett til å klage
 Du kan klage innan 6 veker frå den datoen du fekk brevet. Du finn skjema og informasjon på [nav.no/klage](https://nav.no/klage)
 
 Retten til å klage på innsyn går fram av forvaltningslova § 21.
 <br/>
 <br/>
 <br/>
-**Har du spørsmål?**<br/>
+##### Har du spørsmål?
 Du finn nyttig informasjon på [nav.no/familie](https://nav.no/familie).
 <br/>
 <br/>

--- a/src/test/resources/expected/innsyn/innsyn_innvilget_en.txt
+++ b/src/test/resources/expected/innsyn/innsyn_innvilget_en.txt
@@ -24,14 +24,14 @@ If you have not received all the information you have requested, you can contact
 
 <br/>
 
-**You have the right to appeal**<br/>
+##### You have the right to appeal
 You may appeal within 6 weeks from the date you received the decision. You will find the relevant form and information at [nav.no/klage](https://nav.no/klage).
 
 The right to appeal regarding access is pursuant to section 21 of the Public Administration Act.
 <br/>
 <br/>
 <br/>
-**Do you have questions?**<br/>
+##### Do you have questions?
 You will find useful information at [nav.no/familie](https://nav.no/familie).
 <br/>
 <br/>

--- a/src/test/resources/expected/innsyn/innsyn_innvilget_nb.txt
+++ b/src/test/resources/expected/innsyn/innsyn_innvilget_nb.txt
@@ -24,14 +24,14 @@ Hvis du ikke har fått alle opplysningene du har bedt om, kan du kontakte oss.
 
 <br/>
 
-**Du har rett til å klage**<br/>
+##### Du har rett til å klage
 Du kan klage innen 6 uker fra den datoen du mottok vedtaket. Du finner skjema og informasjon på [nav.no/klage](https://nav.no/klage)
 
 Retten til å klage på innsyn går fram av forvaltningsloven § 21.
 <br/>
 <br/>
 <br/>
-**Har du spørsmål?**<br/>
+##### Har du spørsmål?
 Du finner nyttig informasjon på [nav.no/familie](https://nav.no/familie).
 <br/>
 <br/>

--- a/src/test/resources/expected/innsyn/innsyn_innvilget_nn.txt
+++ b/src/test/resources/expected/innsyn/innsyn_innvilget_nn.txt
@@ -24,14 +24,14 @@ Dersom du ikkje har fått all opplysningane du har bedt om, kan du kontakte oss.
 
 <br/>
 
-**Du har rett til å klage**<br/>
+##### Du har rett til å klage
 Du kan klage innan 6 veker frå den datoen du fekk brevet. Du finn skjema og informasjon på [nav.no/klage](https://nav.no/klage)
 
 Retten til å klage på innsyn går fram av forvaltningslova § 21.
 <br/>
 <br/>
 <br/>
-**Har du spørsmål?**<br/>
+##### Har du spørsmål?
 Du finn nyttig informasjon på [nav.no/familie](https://nav.no/familie).
 <br/>
 <br/>

--- a/src/test/resources/expected/innvilget-foreldrepenger/avslag/førstegangsbehandling_avslag_en.txt
+++ b/src/test/resources/expected/innvilget-foreldrepenger/avslag/førstegangsbehandling_avslag_en.txt
@@ -1,5 +1,5 @@
 <br/>
-**We have denied the following**
+##### We have denied the following
 * You cannot postpone parental benefit from 19. august 2021 up to and including 24. september 2021 because you are receiving attendance allowance in this period.
   Periods before due date cannot be postponed because you gave birth before 33rd week of pregnancy.
 * You are not entitled to parental benefit from 27. september 2021 up to and including 25. november 2021.

--- a/src/test/resources/expected/innvilget-foreldrepenger/avslag/førstegangsbehandling_avslag_nb.txt
+++ b/src/test/resources/expected/innvilget-foreldrepenger/avslag/førstegangsbehandling_avslag_nb.txt
@@ -1,6 +1,6 @@
 <br/>
 
-**Dette har vi avslått**
+##### Dette har vi avslått
 
 * Du kan ikke utsette foreldrepengene fra og med 19. august 2021 til og med 24. september 2021 fordi du får pleiepenger i denne perioden.
 

--- a/src/test/resources/expected/innvilget-foreldrepenger/avslag/førstegangsbehandling_avslag_nn.txt
+++ b/src/test/resources/expected/innvilget-foreldrepenger/avslag/førstegangsbehandling_avslag_nn.txt
@@ -1,5 +1,5 @@
 <br/>
-**Dette har vi avslått**
+##### Dette har vi avslått
 
 * Du kan ikkje utsetje foreldrepengane frå og med 19. august 2021 til og med 24. september 2021 fordi du får pleiepengar i denne perioden.
 

--- a/src/test/resources/expected/innvilget-foreldrepenger/beregning/innvilget-fp_en_ag_nb.txt
+++ b/src/test/resources/expected/innvilget-foreldrepenger/beregning/innvilget-fp_en_ag_nb.txt
@@ -1,6 +1,6 @@
 <br/>
 
-**Inntekt vi har brukt i beregningen**<br/>
+##### Inntekt vi har brukt i beregningen
 
 Vi har brukt 574 548 kroner i året før skatt i beregningen av foreldrepengene dine.
 

--- a/src/test/resources/expected/innvilget-foreldrepenger/beregning/innvilget-fp_frilans_nb.txt
+++ b/src/test/resources/expected/innvilget-foreldrepenger/beregning/innvilget-fp_frilans_nb.txt
@@ -1,6 +1,6 @@
 <br/>
 
-**Inntekt vi har brukt i beregningen**<br/>
+##### Inntekt vi har brukt i beregningen
 
 Inntekten din som frilanser er 47 879 kroner i måneden. Oppdragsgiveren eller oppdragsgiverne dine har gitt oss disse opplysningene.
 Dette er gjennomsnittet av inntekten din fra de siste tre månedene. Hvis du nettopp har begynt å arbeide som frilanser, har vi brukt inntektene etter at du startet.

--- a/src/test/resources/expected/innvilget-foreldrepenger/beregning/innvilget-fp_kun_ytelse_nb.txt
+++ b/src/test/resources/expected/innvilget-foreldrepenger/beregning/innvilget-fp_kun_ytelse_nb.txt
@@ -1,6 +1,6 @@
 <br/>
 
-**Inntekt vi har brukt i beregningen**<br/>
+##### Inntekt vi har brukt i beregningen
 
 Vi har brukt 390 000 kroner i året før skatt i beregningen av foreldrepengene dine.
 

--- a/src/test/resources/expected/innvilget-foreldrepenger/beregning/innvilget-fp_næring_nb.txt
+++ b/src/test/resources/expected/innvilget-foreldrepenger/beregning/innvilget-fp_næring_nb.txt
@@ -1,6 +1,6 @@
 <br/>
 
-**Inntekt vi har brukt i beregningen**<br/>
+##### Inntekt vi har brukt i beregningen
 
 Vi har beregnet foreldrepengene dine ut fra en årsinntekt på 540 000 kroner. Dette er gjennomsnittet av inntekten du hadde i 2019, 2018 og 2017.
 

--- a/src/test/resources/expected/innvilget-foreldrepenger/beregning/innvilget-fp_to_ag_en.txt
+++ b/src/test/resources/expected/innvilget-foreldrepenger/beregning/innvilget-fp_to_ag_en.txt
@@ -1,5 +1,5 @@
 <br/>
-**Income we have used in the calculation**<br/>
+##### Income we have used in the calculation
 We have used the income figure of 574 548 kroner a year before taxes to calculate your parental benefit.
 Your income at ARBEIDSGIVER 1 is 47 879 kroner per month.
 Your income at ARBEIDSGIVER 2 is 54 321 kroner per month.

--- a/src/test/resources/expected/innvilget-foreldrepenger/beregning/innvilget-fp_to_ag_nb.txt
+++ b/src/test/resources/expected/innvilget-foreldrepenger/beregning/innvilget-fp_to_ag_nb.txt
@@ -1,6 +1,6 @@
 <br/>
 
-**Inntekt vi har brukt i beregningen**<br/>
+##### Inntekt vi har brukt i beregningen
 
 Vi har brukt 574 548 kroner i året før skatt i beregningen av foreldrepengene dine.
 

--- a/src/test/resources/expected/innvilget-foreldrepenger/beregning/innvilget-fp_to_ag_nn.txt
+++ b/src/test/resources/expected/innvilget-foreldrepenger/beregning/innvilget-fp_to_ag_nn.txt
@@ -1,6 +1,6 @@
 <br/>
 
-**Inntekt vi har brukt i berekninga**<br/>
+##### Inntekt vi har brukt i berekninga
 
 Vi har brukt 574 548 kroner i året før skatt når vi har berekna foreldrepengane dine.
 

--- a/src/test/resources/expected/innvilget-foreldrepenger/dodt_barn/forstegangsbehandling_en.txt
+++ b/src/test/resources/expected/innvilget-foreldrepenger/dodt_barn/forstegangsbehandling_en.txt
@@ -4,7 +4,7 @@ You will receive 2 455 kroner per day before taxes. This is 53 191 kroner on ave
 We pay parental benefit to your employer because you receive wages while on leave.
 The decision has been made in accordance with the National Insurance Act §§ 14-9, 14-10 og 14-12.
 <br/>
-**Income we have used in the calculation**<br/>
+##### Income we have used in the calculation
 Your income at ADVOKATEN AS is 75 000 kroner per month. Your employer has provided us with this information.
 This is the average of your income from the last three months before the start of the parental benefit period. If you have just started working, changed your employment situation or your pay has changed, we have used your monthly income after the change took place.
 Your parental benefit has been stipulated at 638 394 kroner per year, which is six times the national insurance base amount. You earn more than this, but you will not receive parental benefit for the portion of your income that exceeds six times the national insurance base amount.

--- a/src/test/resources/expected/innvilget-foreldrepenger/dodt_barn/forstegangsbehandling_nb.txt
+++ b/src/test/resources/expected/innvilget-foreldrepenger/dodt_barn/forstegangsbehandling_nb.txt
@@ -11,7 +11,7 @@ Vedtaket er gjort etter folketrygdloven §§ 14-9, 14-10 og 14-12.
 
 <br/>
 
-**Inntekt vi har brukt i beregningen**<br/>
+##### Inntekt vi har brukt i beregningen
 Inntekten din hos ADVOKATEN AS er 75 000 kroner i måneden. Arbeidsgiveren din har gitt oss disse opplysningene.
 
 Dette er gjennomsnittet av inntekten din fra de siste tre månedene. Hvis du nettopp har begynt å arbeide, byttet arbeidsforhold eller lønnen din har endret seg, har vi brukt månedsinntektene etter at endringen skjedde.

--- a/src/test/resources/expected/innvilget-foreldrepenger/dodt_barn/forstegangsbehandling_nn.txt
+++ b/src/test/resources/expected/innvilget-foreldrepenger/dodt_barn/forstegangsbehandling_nn.txt
@@ -11,7 +11,7 @@ Vedtaket er gjort etter folketrygdlova §§ 14-9, 14-10 og 14-12.
 
 <br/>
 
-**Inntekt vi har brukt i berekninga**<br/>
+##### Inntekt vi har brukt i berekninga
 Inntekta di hos ADVOKATEN AS er 75 000 kroner i månaden. Arbeidsgivaren din har gitt oss desse opplysningane.
 
 Dette er gjennomsnittet av inntekta di frå dei siste tre månadene. Dersom du nettopp har begynt å arbeide, har bytta arbeidsforhold, eller dersom lønna di har endra seg, har vi brukt månadsinntektene etter at endringa skjedde.

--- a/src/test/resources/expected/innvilget-foreldrepenger/forstegangsbehandling/gradering_nb.txt
+++ b/src/test/resources/expected/innvilget-foreldrepenger/forstegangsbehandling/gradering_nb.txt
@@ -21,7 +21,7 @@ Fødselsnummer: 300220 12345
 
 <br/>
 
-**Dette har vi innvilget**
+##### Dette har vi innvilget
 
 Du tar ut 50 prosent foreldrepenger fra og med 19. mai 2021 til og med 14. desember 2021 fordi du jobber 50 prosent hos TULLE TRANSPORT AS. I denne perioden får du 1 356 kroner per dag før skatt.
 
@@ -34,7 +34,7 @@ Pengene er på kontoen din innen den 25. hver måned. Sjekk utbetalingene dine p
 
 Det er 25 dager igjen av kvoten din, og 10 dager som dere begge kan ta ut. Disse dagene må det søkes om innen 14. desember 2021.
 
-**Du har flere arbeidsgivere**
+##### Du har flere arbeidsgivere
 
 Du jobber hos flere arbeidsgivere i samme periode. Det er kun mulig å kombinere foreldrepenger med arbeid hos én arbeidsgiver om gangen. Det betyr at det bare er perioden din hos TULLE TRANSPORT AS som blir forlenget.
 
@@ -42,7 +42,7 @@ Vedtaket er gjort etter folketrygdloven §§ 14-12 og 14-16.
 
 <br/>
 
-**Inntekt vi har brukt i beregningen**<br/>
+##### Inntekt vi har brukt i beregningen
 
 Inntekten din hos TULLE TRANSPORT AS er 47 585 kroner i måneden.
 
@@ -52,30 +52,30 @@ Arbeidsgiverne dine har gitt oss disse opplysningene.
 
 Dette er gjennomsnittet av inntekten din fra de siste tre månedene. Hvis du nettopp har begynt å arbeide, byttet arbeidsforhold eller lønnen din har endret seg, har vi brukt månedsinntektene etter at endringen skjedde.
 
-**Hva skjer hvis du får utbetalt foreldrepenger og lønn for samme periode?**
+##### Hva skjer hvis du får utbetalt foreldrepenger og lønn for samme periode?
 
 Hvis du får utbetalt for mye i foreldrepenger, kan utbetalingen din bli redusert i neste måned.
 
 <br/>
 
-**Du må melde fra om endringer**<br/>
+##### Du må melde fra om endringer
 Dersom det skjer endringer som kan ha betydning for stønaden du får utbetalt, må du straks melde fra til NAV. Du finner mer informasjon på [nav.no/rettogplikt](https://nav.no/rettogplikt).
 <br/>
 <br/>
 <br/>
-**Du har rett til å klage**<br/>
+##### Du har rett til å klage
 Du kan klage innen 6 uker fra den datoen du mottok vedtaket. Du finner skjema og informasjon på [nav.no/klage](https://nav.no/klage).
 <br/>
 <br/>
 <br/>
-**Du har rett til innsyn**<br/>
+##### Du har rett til innsyn
 På [nav.no/dittnav](https://nav.no/dittnav) kan du se dokumentene i saken din.
 <br/>
 <br/>
 <br/>
 <div style="break-inside: avoid; page-break-inside: avoid">
 
-**Har du spørsmål?**<br/>
+##### Har du spørsmål?
 Du finner nyttig informasjon på [nav.no/familie](https://nav.no/familie).
 <br/>
 <br/>

--- a/src/test/resources/expected/innvilget-foreldrepenger/forstegangsbehandling/med_avslag_periode_en.txt
+++ b/src/test/resources/expected/innvilget-foreldrepenger/forstegangsbehandling/med_avslag_periode_en.txt
@@ -18,7 +18,7 @@ National identity number: 300220 12345
 You will receive 1 618 kroner per day before taxes starting from 4. juni 2022. This is 35 056 kroner on average per month. The last day you will receive parental benefit is 4. november 2022.
 Your employers pays pays you wages while you are on leave. The remainder of the parental benefit will be paid by NAV within the 25th of each month. Check your payments at [nav.no/utbetalinger](https://nav.no/utbetalinger).
 <br/>
-**We have granted the following**
+##### We have granted the following
 * You are taking 20 per cent parental benefit from 24. februar 2021 up to and including 26. mars 2021 because you are working 80 per cent at ARBEIDSGIVER 1. In this period you will receive 1 618 kroner per day before taxes.
   In the same period, you will be on 100 per cent parental leave from your job at ARBEIDSGIVER 2.
 * You are taking parental benefit from 29. mars 2021 up to and including 05. mai 2020. During this period, you will receive 1 939 kroner per day before taxes.
@@ -30,14 +30,14 @@ Your employers pays pays you wages while you are on leave. The remainder of the 
 * You are taking 20 per cent parental benefit from 18. august 2021 up to and including 05. desember 2021 because you are working 80 per cent at ARBEIDSGIVER 1. In this period you will receive 80 kroner per day before taxes.
   In the same period, you will be on 100 per cent parental leave from your job at ARBEIDSGIVER 2.
 There are 0 days left of your quota and 10 days left that you both can take. These days must be applied for by 4. november 2022.
-**You have more than one employer**
+##### You have more than one employer
 You are working for several employers during the same period. It is only possible to combine parental benefit with work at one employer at a time. This means that it is only your period at ARBEIDSGIVER 1 that will be extended.
 <br/>
-**We have denied the following**
+##### We have denied the following
 You are not entitled to parental benefit from 06. desember 2021 up to and including 07. desember 2021 because there are no more days left of the parental benefit period.
 The decision has been made in accordance with the National Insurance Act §§ 14-9, 14-12 og 14-16.
 <br/>
-**Income we have used in the calculation**<br/>
+##### Income we have used in the calculation
 We have used the income figure of 504 360 kroner a year before taxes to calculate your parental benefit.
 Your income at ARBEIDSGIVER 1 is 8 697 kroner per month.
 Your income at ARBEIDSGIVER 2 is 33 333 kroner per month.
@@ -45,23 +45,23 @@ Your employers have provided us with this information.
 This is the average of your income from the last three months before the start of the parental benefit period. If you have just started working, changed your employment situation or your pay has changed, we have used your monthly income after the change took place.
 The calculation has been made in accordance with the National Insurance Act Sections §§ 14-7 og 8-30.
 <br/>
-**You must notify any changes**<br/>
+##### You must notify any changes
 You must notify NAV immediately of any changes that might affect benefits you receive. See [nav.no/rettogplikt](https://nav.no/rettogplikt) for more detailed information.
 <br/>
 <br/>
 <br/>
-**You have the right to appeal**<br/>
+##### You have the right to appeal
 You may appeal within 6 weeks from the date you received the decision. You will find the relevant form and information at [nav.no/klage](https://nav.no/klage).
 <br/>
 <br/>
 <br/>
-**You have right of access**<br/>
+##### You have right of access
 Go to [nav.no/dittnav](https://nav.no/dittnav) to see the documents in your case.
 <br/>
 <br/>
 <br/>
 <div style="break-inside: avoid; page-break-inside: avoid">
-**Do you have questions?**<br/>
+##### Do you have questions?
 You will find useful information at [nav.no/familie](https://nav.no/familie).
 <br/>
 <br/>

--- a/src/test/resources/expected/innvilget-foreldrepenger/forstegangsbehandling/med_avslag_periode_nb.txt
+++ b/src/test/resources/expected/innvilget-foreldrepenger/forstegangsbehandling/med_avslag_periode_nb.txt
@@ -25,7 +25,7 @@ Arbeidsgiverne dine betaler deg lønn mens du har permisjon. Resten av foreldrep
 
 <br/>
 
-**Dette har vi innvilget**
+##### Dette har vi innvilget
 
 * Du tar ut 20 prosent foreldrepenger fra og med 24. februar 2021 til og med 26. mars 2021 fordi du jobber 80 prosent hos ARBEIDSGIVER 1. I denne perioden får du 1 618 kroner per dag før skatt.
 
@@ -49,13 +49,13 @@ Arbeidsgiverne dine betaler deg lønn mens du har permisjon. Resten av foreldrep
 
 Det er 0 dager igjen av kvoten din, og 10 dager som dere begge kan ta ut. Disse dagene må det søkes om innen 4. november 2022.
 
-**Du har flere arbeidsgivere**
+##### Du har flere arbeidsgivere
 
 Du jobber hos flere arbeidsgivere i samme periode. Det er kun mulig å kombinere foreldrepenger med arbeid hos én arbeidsgiver om gangen. Det betyr at det bare er perioden din hos ARBEIDSGIVER 1 som blir forlenget.
 
 <br/>
 
-**Dette har vi avslått**
+##### Dette har vi avslått
 
 Du har ikke rett til foreldrepenger fra og med 06. desember 2021 til og med 07. desember 2021 fordi det ikke er flere dager igjen av foreldrepengeperioden.
 
@@ -63,7 +63,7 @@ Vedtaket er gjort etter folketrygdloven §§ 14-9, 14-12 og 14-16.
 
 <br/>
 
-**Inntekt vi har brukt i beregningen**<br/>
+##### Inntekt vi har brukt i beregningen
 
 Vi har brukt 504 360 kroner i året før skatt i beregningen av foreldrepengene dine.
 
@@ -79,24 +79,24 @@ Beregningen er gjort etter folketrygdloven §§ 14-7 og 8-30.
 
 <br/>
 
-**Du må melde fra om endringer**<br/>
+##### Du må melde fra om endringer
 Dersom det skjer endringer som kan ha betydning for stønaden du får utbetalt, må du straks melde fra til NAV. Du finner mer informasjon på [nav.no/rettogplikt](https://nav.no/rettogplikt).
 <br/>
 <br/>
 <br/>
-**Du har rett til å klage**<br/>
+##### Du har rett til å klage
 Du kan klage innen 6 uker fra den datoen du mottok vedtaket. Du finner skjema og informasjon på [nav.no/klage](https://nav.no/klage).
 <br/>
 <br/>
 <br/>
-**Du har rett til innsyn**<br/>
+##### Du har rett til innsyn
 På [nav.no/dittnav](https://nav.no/dittnav) kan du se dokumentene i saken din.
 <br/>
 <br/>
 <br/>
 <div style="break-inside: avoid; page-break-inside: avoid">
 
-**Har du spørsmål?**<br/>
+##### Har du spørsmål?
 Du finner nyttig informasjon på [nav.no/familie](https://nav.no/familie).
 <br/>
 <br/>

--- a/src/test/resources/expected/innvilget-foreldrepenger/forstegangsbehandling/med_avslag_periode_nn.txt
+++ b/src/test/resources/expected/innvilget-foreldrepenger/forstegangsbehandling/med_avslag_periode_nn.txt
@@ -25,7 +25,7 @@ Arbeidsgivarane dine betaler deg lønn mens du har permisjon. Resten av foreldre
 
 <br/>
 
-**Dette har vi innvilga**
+##### Dette har vi innvilga
 
 * Du tek ut 20 prosent foreldrepengar frå og med 24. februar 2021 til og med 26. mars 2021 fordi du jobbar 80 prosent hos ARBEIDSGIVER 1. I denne perioden får du 1 618 kroner per dag før skatt.
 
@@ -49,13 +49,13 @@ Arbeidsgivarane dine betaler deg lønn mens du har permisjon. Resten av foreldre
 
 Det er 0 dagar igjen av kvoten din, og 10 dagar som de begge kan ta ut. Desse dagane må du søkje om innan 4. november 2022.
 
-**Du har fleire arbeidsgivarar**
+##### Du har fleire arbeidsgivarar
 
 Du jobbar hos fleire arbeidsgivarar i same periode. Det er berre mogleg å kombinere foreldrepengar med arbeid hos éin arbeidsgivar om gongen. Det betyr at det berre er perioden din hos ARBEIDSGIVER 1 som blir forlengd.
 
 <br/>
 
-**Dette har vi avslått**
+##### Dette har vi avslått
 
 Du har ikkje rett til foreldrepengar frå og med 06. desember 2021 til og med 07. desember 2021 fordi det ikkje er fleire dagar igjen av foreldrepengeperioden.
 
@@ -63,7 +63,7 @@ Vedtaket er gjort etter folketrygdlova §§ 14-9, 14-12 og 14-16.
 
 <br/>
 
-**Inntekt vi har brukt i berekninga**<br/>
+##### Inntekt vi har brukt i berekninga
 
 Vi har brukt 504 360 kroner i året før skatt når vi har berekna foreldrepengane dine.
 
@@ -79,24 +79,24 @@ Berekninga er gjort etter folketrygdlova §§ 14-7 og 8-30.
 
 <br/>
 
-**Du må melde frå om endringar**<br/>
+##### Du må melde frå om endringar
 Dersom det skjer endringar som kan få følgjer for stønaden du får betalt ut, må du melde frå til NAV med ein gong. Du finn meir informasjon på [nav.no/rettogplikt](https://nav.no/rettogplikt).
 <br/>
 <br/>
 <br/>
-**Du har rett til å klage**<br/>
+##### Du har rett til å klage
 Du kan klage innan 6 veker frå den datoen du fekk vedtaket. Du finn skjema og informasjon på [nav.no/klage](https://nav.no/klage).
 <br/>
 <br/>
 <br/>
-**Du har rett til innsyn**<br/>
+##### Du har rett til innsyn
 På [nav.no/dittnav](https://nav.no/dittnav) kan du sjå dokumenta i saka di.
 <br/>
 <br/>
 <br/>
 <div style="break-inside: avoid; page-break-inside: avoid">
 
-**Har du spørsmål?**<br/>
+##### Har du spørsmål?
 Du finn nyttig informasjon på [nav.no/familie](https://nav.no/familie).
 <br/>
 <br/>

--- a/src/test/resources/expected/innvilget-foreldrepenger/forstegangsbehandling/med_fritekst_nb.txt
+++ b/src/test/resources/expected/innvilget-foreldrepenger/forstegangsbehandling/med_fritekst_nb.txt
@@ -27,7 +27,7 @@ Pengene er på kontoen din innen den 25. hver måned. Sjekk utbetalingene dine p
 
 <br/>
 
-**Dette har vi innvilget**
+##### Dette har vi innvilget
 
 * Du får utsatt foreldrepengene fra og med 7. mai 2021 til og med 30. september 2021 fordi du jobber heltid.
 
@@ -41,7 +41,7 @@ Det er 7 dager igjen av kvoten din, og 0 dager som dere begge kan ta ut. Disse d
 
 <br/>
 
-**Inntekt vi har brukt i beregningen**<br/>
+##### Inntekt vi har brukt i beregningen
 Inntekten din hos Arbeidsgiver 1 er oppgitt av din arbeidsgiver etter
 18.496 kroner i måneden.
 
@@ -60,24 +60,24 @@ Beregningen er gjort etter folketrygdloven §§ 14-7 og 8-30.
 
 <br/>
 
-**Du må melde fra om endringer**<br/>
+##### Du må melde fra om endringer
 Dersom det skjer endringer som kan ha betydning for stønaden du får utbetalt, må du straks melde fra til NAV. Du finner mer informasjon på [nav.no/rettogplikt](https://nav.no/rettogplikt).
 <br/>
 <br/>
 <br/>
-**Du har rett til å klage**<br/>
+##### Du har rett til å klage
 Du kan klage innen 6 uker fra den datoen du mottok vedtaket. Du finner skjema og informasjon på [nav.no/klage](https://nav.no/klage).
 <br/>
 <br/>
 <br/>
-**Du har rett til innsyn**<br/>
+##### Du har rett til innsyn
 På [nav.no/dittnav](https://nav.no/dittnav) kan du se dokumentene i saken din.
 <br/>
 <br/>
 <br/>
 <div style="break-inside: avoid; page-break-inside: avoid">
 
-**Har du spørsmål?**<br/>
+##### Har du spørsmål?
 Du finner nyttig informasjon på [nav.no/familie](https://nav.no/familie).
 <br/>
 <br/>

--- a/src/test/resources/expected/innvilget-foreldrepenger/forstegangsbehandling/uten_gradering_avslag_nb.txt
+++ b/src/test/resources/expected/innvilget-foreldrepenger/forstegangsbehandling/uten_gradering_avslag_nb.txt
@@ -31,7 +31,7 @@ Fordi du fødte før termin, mister du 3 dager med foreldrepenger.
 
 <br/>
 
-**Dette har vi innvilget**
+##### Dette har vi innvilget
 
 * Du tar ut foreldrepenger fra og med 15. april 2021 til og med 18. august 2021. I denne perioden får du 2 209 kroner per dag før skatt.
 
@@ -49,7 +49,7 @@ Vedtaket er gjort etter folketrygdloven § forvaltningsloven § 35.
 
 <br/>
 
-**Inntekt vi har brukt i beregningen**<br/>
+##### Inntekt vi har brukt i beregningen
 
 Vi har brukt 574 548 kroner i året før skatt i beregningen av foreldrepengene dine.
 
@@ -61,24 +61,24 @@ Beregningen er gjort etter folketrygdloven §§ 14-7 og forvaltningsloven § 35.
 
 <br/>
 
-**Du må melde fra om endringer**<br/>
+##### Du må melde fra om endringer
 Dersom det skjer endringer som kan ha betydning for stønaden du får utbetalt, må du straks melde fra til NAV. Du finner mer informasjon på [nav.no/rettogplikt](https://nav.no/rettogplikt).
 <br/>
 <br/>
 <br/>
-**Du har rett til å klage**<br/>
+##### Du har rett til å klage
 Du kan klage innen 6 uker fra den datoen du mottok vedtaket. Du finner skjema og informasjon på [nav.no/klage](https://nav.no/klage).
 <br/>
 <br/>
 <br/>
-**Du har rett til innsyn**<br/>
+##### Du har rett til innsyn
 På [nav.no/dittnav](https://nav.no/dittnav) kan du se dokumentene i saken din.
 <br/>
 <br/>
 <br/>
 <div style="break-inside: avoid; page-break-inside: avoid">
 
-**Har du spørsmål?**<br/>
+##### Har du spørsmål?
 Du finner nyttig informasjon på [nav.no/familie](https://nav.no/familie).
 <br/>
 <br/>

--- a/src/test/resources/expected/innvilget-foreldrepenger/innvilget/innvilget-foreldrepenger_annenaktivitet_næring_nb.txt
+++ b/src/test/resources/expected/innvilget-foreldrepenger/innvilget/innvilget-foreldrepenger_annenaktivitet_næring_nb.txt
@@ -1,6 +1,6 @@
 <br/>
 
-**Dette har vi innvilget**
+##### Dette har vi innvilget
 
 * Du tar ut 50 prosent foreldrepenger fra og med 15. april 2021 til og med 18. august 2021. I denne perioden får du 500 kroner per dag før skatt.
 

--- a/src/test/resources/expected/innvilget-foreldrepenger/innvilget/innvilget-foreldrepenger_arbeidsforhold_nb.txt
+++ b/src/test/resources/expected/innvilget-foreldrepenger/innvilget/innvilget-foreldrepenger_arbeidsforhold_nb.txt
@@ -1,6 +1,6 @@
 <br/>
 
-**Dette har vi innvilget**
+##### Dette har vi innvilget
 
 Du tar ut 40 prosent foreldrepenger fra og med 15. april 2021 til og med 18. august 2021. I denne perioden får du 500 kroner per dag før skatt.
 

--- a/src/test/resources/expected/innvilget-foreldrepenger/innvilget/innvilget-foreldrepenger_enkeltårsaker_en.txt
+++ b/src/test/resources/expected/innvilget-foreldrepenger/innvilget/innvilget-foreldrepenger_enkeltårsaker_en.txt
@@ -1,5 +1,5 @@
 <br/>
-**We have granted the following**
+##### We have granted the following
 * You will receive 100 per cent parental benefit from 1. april 2021 up to and including 2. april 2021. This corresponds to the percentage of a full-time position that the mother is working. The amount of parental benefit you draw cannot be higher than the percentage that the mother is working.
   Even though you are working during this period, you will not be entitled to an extension of your parental benefit period. In order to combine parental benefit with work and get a longer period of parental benefit, the amount you draw must be lower than the percentage that the mother is working.
 * You will receive 100 per cent parental benefit from 3. april 2021 up to and including 4. april 2021.

--- a/src/test/resources/expected/innvilget-foreldrepenger/innvilget/innvilget-foreldrepenger_enkeltårsaker_nb.txt
+++ b/src/test/resources/expected/innvilget-foreldrepenger/innvilget/innvilget-foreldrepenger_enkeltårsaker_nb.txt
@@ -1,6 +1,6 @@
 <br/>
 
-**Dette har vi innvilget**
+##### Dette har vi innvilget
 
 * Du får 100 prosent foreldrepenger fra og med 1. april 2021 til og med 2. april 2021. Dette tilsvarer den stillingsprosenten mor jobber. Det du tar ut i foreldrepenger kan ikke være høyere enn den prosenten mor jobber.
 

--- a/src/test/resources/expected/innvilget-foreldrepenger/innvilget/innvilget-foreldrepenger_enkeltårsaker_nn.txt
+++ b/src/test/resources/expected/innvilget-foreldrepenger/innvilget/innvilget-foreldrepenger_enkeltårsaker_nn.txt
@@ -1,6 +1,6 @@
 <br/>
 
-**Dette har vi innvilga**
+##### Dette har vi innvilga
 
 * Du får 100 prosent foreldrepengar frå og med 1. april 2021 til og med 2. april 2021. Dette svarer til den stillingsprosenten mor jobbar. Det du tek ut i foreldrepengar, kan ikkje vere høgare enn den prosenten mor jobbar.
 

--- a/src/test/resources/expected/innvilget-foreldrepenger/innvilget/innvilget-foreldrepenger_fullt_nb.txt
+++ b/src/test/resources/expected/innvilget-foreldrepenger/innvilget/innvilget-foreldrepenger_fullt_nb.txt
@@ -1,6 +1,6 @@
 <br/>
 
-**Dette har vi innvilget**
+##### Dette har vi innvilget
 
 * Du tar ut foreldrepenger fra og med 15. april 2021 til og med 18. august 2021. I denne perioden får du 1 000 kroner per dag før skatt.
 

--- a/src/test/resources/expected/innvilget-foreldrepenger/innvilget/innvilget-foreldrepenger_innvilget_og_avslått_nb.txt
+++ b/src/test/resources/expected/innvilget-foreldrepenger/innvilget/innvilget-foreldrepenger_innvilget_og_avslått_nb.txt
@@ -1,6 +1,6 @@
 <br/>
 
-**Dette har vi innvilget**
+##### Dette har vi innvilget
 
 Du tar ut foreldrepenger fra og med 15. april 2021 til og med 18. august 2021. I denne perioden får du 1 000 kroner per dag før skatt.
 

--- a/src/test/resources/expected/innvilget-foreldrepenger/innvilget/innvilget-foreldrepenger_prosent_nb.txt
+++ b/src/test/resources/expected/innvilget-foreldrepenger/innvilget/innvilget-foreldrepenger_prosent_nb.txt
@@ -1,6 +1,6 @@
 <br/>
 
-**Dette har vi innvilget**
+##### Dette har vi innvilget
 
 * Du tar ut 50.1 prosent foreldrepenger fra og med 15. april 2021 til og med 18. august 2021. I denne perioden får du 500 kroner per dag før skatt.
 

--- a/src/test/resources/expected/innvilget-foreldrepenger/revurdering/foreldrepenger_endret_barn_dod_nb.txt
+++ b/src/test/resources/expected/innvilget-foreldrepenger/revurdering/foreldrepenger_endret_barn_dod_nb.txt
@@ -29,18 +29,18 @@ Vedtaket er gjort etter folketrygdloven §§ 14-9, 14-10, 14-11 og 14-12.
 
 <br/>
 
-**Du har rett til å klage**<br/>
+##### Du har rett til å klage
 Du kan klage innen 6 uker fra den datoen du mottok vedtaket. Du finner skjema og informasjon på [nav.no/klage](https://nav.no/klage).
 <br/>
 <br/>
 <br/>
-**Du har rett til innsyn**<br/>
+##### Du har rett til innsyn
 På [nav.no/dittnav](https://nav.no/dittnav) kan du se dokumentene i saken din.
 <br/>
 <br/>
 <br/>
 <div style="break-inside: avoid; page-break-inside: avoid">
-**Har du spørsmål?**<br/>
+##### Har du spørsmål?
 Du finner nyttig informasjon på [nav.no/familie](https://nav.no/familie).
 <br/>
 <br/>

--- a/src/test/resources/expected/innvilget-foreldrepenger/revurdering/foreldrepenger_endret_endring_i_beregning_nb.txt
+++ b/src/test/resources/expected/innvilget-foreldrepenger/revurdering/foreldrepenger_endret_endring_i_beregning_nb.txt
@@ -25,7 +25,7 @@ Du får 1 436 kroner per dag før skatt. Dette er i gjennomsnitt 31 113 kroner i
 
 <br/>
 
-**Inntekt vi har brukt i beregningen**<br/>
+##### Inntekt vi har brukt i beregningen
 
 Inntekten din hos FIRMA AS er 38 904 kroner i måneden. Arbeidsgiveren din har gitt oss disse opplysningene.
 
@@ -37,24 +37,24 @@ Hvis arbeidsgiver kommer med nye opplysninger om inntekten du hadde før du star
 
 <br/>
 
-**Du må melde fra om endringer**<br/>
+##### Du må melde fra om endringer
 Dersom det skjer endringer som kan ha betydning for stønaden du får utbetalt, må du straks melde fra til NAV. Du finner mer informasjon på [nav.no/rettogplikt](https://nav.no/rettogplikt).
 <br/>
 <br/>
 <br/>
-**Du har rett til å klage**<br/>
+##### Du har rett til å klage
 Du kan klage innen 6 uker fra den datoen du mottok vedtaket. Du finner skjema og informasjon på [nav.no/klage](https://nav.no/klage).
 <br/>
 <br/>
 <br/>
-**Du har rett til innsyn**<br/>
+##### Du har rett til innsyn
 På [nav.no/dittnav](https://nav.no/dittnav) kan du se dokumentene i saken din.
 <br/>
 <br/>
 <br/>
 <div style="break-inside: avoid; page-break-inside: avoid">
 
-**Har du spørsmål?**<br/>
+##### Har du spørsmål?
 Du finner nyttig informasjon på [nav.no/familie](https://nav.no/familie).
 <br/>
 <br/>

--- a/src/test/resources/expected/innvilget-foreldrepenger/revurdering/foreldrepenger_endret_nb.txt
+++ b/src/test/resources/expected/innvilget-foreldrepenger/revurdering/foreldrepenger_endret_nb.txt
@@ -21,7 +21,7 @@ Fødselsnummer: 123456 78901
 
 <br/>
 
-**Dette har vi innvilget**
+##### Dette har vi innvilget
 
 Du tar ut foreldrepenger fra og med 30. juni 2020 til og med 21. september 2020. I denne perioden får du 1 871 kroner per dag før skatt.
 
@@ -31,7 +31,7 @@ Den siste dagen med foreldrepenger er 21. september 2020.
 
 <br/>
 
-**Dette har vi avslått**
+##### Dette har vi avslått
 
 * Det er ikke søkt om foreldrepenger eller utsettelse fra og med 22. september 2020 til og med 9. november 2020. Derfor er 35 dager tapt.
 
@@ -45,24 +45,24 @@ Tester at fritekst kommer etter vedtakshjemler når endring i uttak
 
 <br/>
 
-**Du må melde fra om endringer**<br/>
+##### Du må melde fra om endringer
 Dersom det skjer endringer som kan ha betydning for stønaden du får utbetalt, må du straks melde fra til NAV. Du finner mer informasjon på [nav.no/rettogplikt](https://nav.no/rettogplikt).
 <br/>
 <br/>
 <br/>
-**Du har rett til å klage**<br/>
+##### Du har rett til å klage
 Du kan klage innen 6 uker fra den datoen du mottok vedtaket. Du finner skjema og informasjon på [nav.no/klage](https://nav.no/klage).
 <br/>
 <br/>
 <br/>
-**Du har rett til innsyn**<br/>
+##### Du har rett til innsyn
 På [nav.no/dittnav](https://nav.no/dittnav) kan du se dokumentene i saken din.
 <br/>
 <br/>
 <br/>
 <div style="break-inside: avoid; page-break-inside: avoid">
 
-**Har du spørsmål?**<br/>
+##### Har du spørsmål?
 Du finner nyttig informasjon på [nav.no/familie](https://nav.no/familie).
 <br/>
 <br/>

--- a/src/test/resources/expected/innvilget-foreldrepenger/revurdering/foreldrepenger_innvilget_endring_i_uttak_en.txt
+++ b/src/test/resources/expected/innvilget-foreldrepenger/revurdering/foreldrepenger_innvilget_endring_i_uttak_en.txt
@@ -18,7 +18,7 @@ National identity number: 123456 12345
 We have reconsidered your case, and you are entitled to parental benefit. We have therefore changed the decision you previously have received.
 You will receive 1 871 kroner per day before taxes starting from 18. juni 2020. This is 40 538 kroner on average per month. The last day you will receive parental benefit is 13. august 2021.
 <br/>
-**We have granted the following**
+##### We have granted the following
 * Your parental benefit is postponed from 18. juni 2020 up to and including 21. juli 2020 because you are working full time.
 * You are taking parental benefit from 22. juli 2020 up to and including 14. august 2020. During this period, you will receive 1 871 kroner per day before taxes.
 * Your parental benefit is postponed from 17. august 2020 up to and including 22. september 2020 because you are working full time.
@@ -35,26 +35,26 @@ The parental benefit amounts to the same as before. Check your payments at [nav.
 The last day of parental benefit is 13. august 2021.
 The decision has been made in accordance with the National Insurance Act §§ 14-11, 14-12 og forvaltningsloven § 35.
 Because you have chosen 80 per cent parental benefit, you will be paid less per month.
-**What happens if you receive parental benefit and salary for the same period?**
+##### What happens if you receive parental benefit and salary for the same period?
 If you have been paid the parental benefit at the same time as you have worked or postponed days because you have taken holidays, you have been paid an excess amount of parental benefit. This means that the payment for the next month can be reduced by the excess amount you received.
 <br/>
-**You must notify any changes**<br/>
+##### You must notify any changes
 You must notify NAV immediately of any changes that might affect benefits you receive. See [nav.no/rettogplikt](https://nav.no/rettogplikt) for more detailed information.
 <br/>
 <br/>
 <br/>
-**You have the right to appeal**<br/>
+##### You have the right to appeal
 You may appeal within 6 weeks from the date you received the decision. You will find the relevant form and information at [nav.no/klage](https://nav.no/klage).
 <br/>
 <br/>
 <br/>
-**You have right of access**<br/>
+##### You have right of access
 Go to [nav.no/dittnav](https://nav.no/dittnav) to see the documents in your case.
 <br/>
 <br/>
 <br/>
 <div style="break-inside: avoid; page-break-inside: avoid">
-**Do you have questions?**<br/>
+##### Do you have questions?
 You will find useful information at [nav.no/familie](https://nav.no/familie).
 <br/>
 <br/>
@@ -65,5 +65,5 @@ NAV Familie- og Pensjonsytelser
 <br/><br/>
 This case has been electronically processed by our administration system, which means that this letter has not been signed by a case worker.
 <br/><br/>
-**This is a copy, the orginal has been sent to the guardian**.
+##### This is a copy, the orginal has been sent to the guardian.
 </div>

--- a/src/test/resources/expected/innvilget-foreldrepenger/revurdering/foreldrepenger_innvilget_endring_i_uttak_nb.txt
+++ b/src/test/resources/expected/innvilget-foreldrepenger/revurdering/foreldrepenger_innvilget_endring_i_uttak_nb.txt
@@ -25,7 +25,7 @@ Du får 1 871 kroner per dag før skatt fra og med 18. juni 2020. Dette er i gje
 
 <br/>
 
-**Dette har vi innvilget**
+##### Dette har vi innvilget
 
 * Du får utsatt foreldrepengene fra og med 18. juni 2020 til og med 21. juli 2020 fordi du jobber heltid.
 
@@ -59,30 +59,30 @@ Vedtaket er gjort etter folketrygdloven §§ 14-11, 14-12 og forvaltningsloven �
 
 Fordi du har valgt 80 prosent foreldrepenger, får du mindre utbetalt i måneden.
 
-**Hva skjer hvis du får utbetalt foreldrepenger og lønn for samme periode?**
+##### Hva skjer hvis du får utbetalt foreldrepenger og lønn for samme periode?
 
 Hvis du har fått utbetalt foreldrepenger samtidig som du har jobbet eller utsatt dager fordi du har hatt ferie, har du fått utbetalt for mye i foreldrepenger. Det betyr at utbetalingen i neste måned kan bli redusert med det du har fått utbetalt for mye.
 
 <br/>
 
-**Du må melde fra om endringer**<br/>
+##### Du må melde fra om endringer
 Dersom det skjer endringer som kan ha betydning for stønaden du får utbetalt, må du straks melde fra til NAV. Du finner mer informasjon på [nav.no/rettogplikt](https://nav.no/rettogplikt).
 <br/>
 <br/>
 <br/>
-**Du har rett til å klage**<br/>
+##### Du har rett til å klage
 Du kan klage innen 6 uker fra den datoen du mottok vedtaket. Du finner skjema og informasjon på [nav.no/klage](https://nav.no/klage).
 <br/>
 <br/>
 <br/>
-**Du har rett til innsyn**<br/>
+##### Du har rett til innsyn
 På [nav.no/dittnav](https://nav.no/dittnav) kan du se dokumentene i saken din.
 <br/>
 <br/>
 <br/>
 <div style="break-inside: avoid; page-break-inside: avoid">
 
-**Har du spørsmål?**<br/>
+##### Har du spørsmål?
 Du finner nyttig informasjon på [nav.no/familie](https://nav.no/familie).
 <br/>
 <br/>
@@ -97,6 +97,6 @@ Vedtaket har blitt automatisk saksbehandlet av vårt fagsystem. Vedtaksbrevet er
 
 <br/><br/>
 
-**Dette er en kopi, orginal er sendt til verge**.
+##### Dette er en kopi, orginal er sendt til verge.
 
 </div>

--- a/src/test/resources/expected/innvilget-foreldrepenger/revurdering/foreldrepenger_innvilget_endring_i_uttak_nn.txt
+++ b/src/test/resources/expected/innvilget-foreldrepenger/revurdering/foreldrepenger_innvilget_endring_i_uttak_nn.txt
@@ -25,7 +25,7 @@ Du får 1 871 kroner per dag før skatt frå og med 18. juni 2020. Dette er i gj
 
 <br/>
 
-**Dette har vi innvilga**
+##### Dette har vi innvilga
 
 * Du får utsett foreldrepengane frå og med 18. juni 2020 til og med 21. juli 2020 fordi du jobbar heiltid.
 
@@ -59,30 +59,30 @@ Vedtaket er gjort etter folketrygdlova §§ 14-11, 14-12 og forvaltningsloven §
 
 Fordi du har valt 80 prosent foreldrepengar, får du mindre utbetalt i månaden.
 
-**Kva skjer dersom du får utbetalt foreldrepengar og løn for same periode?**
+##### Kva skjer dersom du får utbetalt foreldrepengar og løn for same periode?
 
 Dersom du har fått utbetalt foreldrepengar samtidig som du har jobba eller hatt ferie, har du fått utbetalt for mykje i foreldrepengar. Det betyr at utbetalinga i neste månad kan bli redusert med det du har fått utbetalt for mykje.
 
 <br/>
 
-**Du må melde frå om endringar**<br/>
+##### Du må melde frå om endringar
 Dersom det skjer endringar som kan få følgjer for stønaden du får betalt ut, må du melde frå til NAV med ein gong. Du finn meir informasjon på [nav.no/rettogplikt](https://nav.no/rettogplikt).
 <br/>
 <br/>
 <br/>
-**Du har rett til å klage**<br/>
+##### Du har rett til å klage
 Du kan klage innan 6 veker frå den datoen du fekk vedtaket. Du finn skjema og informasjon på [nav.no/klage](https://nav.no/klage).
 <br/>
 <br/>
 <br/>
-**Du har rett til innsyn**<br/>
+##### Du har rett til innsyn
 På [nav.no/dittnav](https://nav.no/dittnav) kan du sjå dokumenta i saka di.
 <br/>
 <br/>
 <br/>
 <div style="break-inside: avoid; page-break-inside: avoid">
 
-**Har du spørsmål?**<br/>
+##### Har du spørsmål?
 Du finn nyttig informasjon på [nav.no/familie](https://nav.no/familie).
 <br/>
 <br/>
@@ -97,6 +97,6 @@ Vedtaket har blitt automatisk saksbehandla av fagsystemet vårt. Det er derfor i
 
 <br/><br/>
 
-**Dette er ein kopi, orginal er sendt til verje**.
+##### Dette er ein kopi, orginal er sendt til verje.
 
 </div>

--- a/src/test/resources/expected/klage-avvist/fp_ka_tilbakekreving_alle_nb.txt
+++ b/src/test/resources/expected/klage-avvist/fp_ka_tilbakekreving_alle_nb.txt
@@ -21,18 +21,18 @@ Vi har avvist klagen din fordi
 * du ikke har sagt hva det er du klager på
 Vedtaket er gjort etter folketrygdloven § 21-12 og forvaltningsloven §§ 28, 31, 32 og 34.
 <br/>
-**Du har rett til å klage**<br/>
+##### Du har rett til å klage
 Du kan klage innen 6 uker fra den datoen du mottok vedtaket. Du finner skjema og informasjon på [nav.no/klage](https://nav.no/klage).
 <br/>
 <br/>
 <br/>
-**Du har rett til innsyn**<br/>
+##### Du har rett til innsyn
 På [nav.no/dittnav](https://nav.no/dittnav) kan du se dokumentene i saken din.
 <br/>
 <br/>
 <br/>
 <div style="break-inside: avoid; page-break-inside: avoid">
-**Har du spørsmål?**<br/>
+##### Har du spørsmål?
 Du finner nyttig informasjon på [nav.no/familie](https://nav.no/familie).
 <br/>
 <br/>

--- a/src/test/resources/expected/klage-avvist/fp_ka_tilbakekreving_alle_nn.txt
+++ b/src/test/resources/expected/klage-avvist/fp_ka_tilbakekreving_alle_nn.txt
@@ -21,18 +21,18 @@ Vi har avvist klaga di fordi
 * du ikkje har sagt kva det er du klagar på
 Vedtaket er gjort etter folketrygdloven § 21-12 og forvaltningsloven §§ 28, 31, 32 og 34.
 <br/>
-**Du har rett til å klage**<br/>
+##### Du har rett til å klage
 Du kan klage innan 6 veker frå den datoen du fekk vedtaket. Du finn skjema og informasjon på [nav.no/klage](https://nav.no/klage).
 <br/>
 <br/>
 <br/>
-**Du har rett til innsyn**<br/>
+##### Du har rett til innsyn
 På [nav.no/dittnav](https://nav.no/dittnav) kan du sjå dokumenta i saka di.
 <br/>
 <br/>
 <br/>
 <div style="break-inside: avoid; page-break-inside: avoid">
-**Har du spørsmål?**<br/>
+##### Har du spørsmål?
 Du finn nyttig informasjon på [nav.no/familie](https://nav.no/familie).
 <br/>
 <br/>

--- a/src/test/resources/expected/klage-avvist/svp_nfp_ikke-tilbakekreving_nb.txt
+++ b/src/test/resources/expected/klage-avvist/svp_nfp_ikke-tilbakekreving_nb.txt
@@ -16,18 +16,18 @@ Fødselsnummer: 300220 12345
 Vi har avvist klagen din fordi det du har klaget på ikke er et vedtak
 Vedtaket er gjort etter folketrygdloven § 21-12 og forvaltningsloven §§ 28, 31, 32 og 34.
 <br/>
-**Du har rett til å klage**<br/>
+##### Du har rett til å klage
 Du kan klage innen 6 uker fra den datoen du mottok vedtaket. Du finner skjema og informasjon på [nav.no/klage](https://nav.no/klage).
 <br/>
 <br/>
 <br/>
-**Du har rett til innsyn**<br/>
+##### Du har rett til innsyn
 På [nav.no/dittnav](https://nav.no/dittnav) kan du se dokumentene i saken din.
 <br/>
 <br/>
 <br/>
 <div style="break-inside: avoid; page-break-inside: avoid">
-**Har du spørsmål?**<br/>
+##### Har du spørsmål?
 Du finner nyttig informasjon på [nav.no/familie](https://nav.no/familie).
 <br/>
 <br/>

--- a/src/test/resources/expected/klage-hjemsendt/es_ikke-opphevet_ikke-tilbakekreving_nb.txt
+++ b/src/test/resources/expected/klage-hjemsendt/es_ikke-opphevet_ikke-tilbakekreving_nb.txt
@@ -15,23 +15,19 @@ Fødselsnummer: 300220 12345
 </p>
 Vi kan ikke vurdere om du har rett til engangsstønad fordi vi mangler opplysninger. Derfor har vi sendt saken din tilbake til NAV Familie- og pensjonsytelser. De skal behandle saken på nytt.
 Informasjon om saksbehandlingstid finner du på nav.no.
-<br/>
-<br/>
-**Dette har vi lagt vekt på i vurderingen vår**
-<br/>
+##### Dette har vi lagt vekt på i vurderingen vår
 FRITEKST
-<br/>
 <br/>
 Du kan ikke klage på denne beslutningen. Dette følger av forvaltningsloven §§ 2 og 28.
 Har du nye opplysninger eller ønsker å uttale deg, kan du sende dette via [nav.no/ettersendelser](https://nav.no/ettersendelser) innen 14. juni 2021.
 <br/>
-**Du har rett til innsyn**<br/>
+##### Du har rett til innsyn
 På [nav.no/dittnav](https://nav.no/dittnav) kan du se dokumentene i saken din.
 <br/>
 <br/>
 <br/>
 <div style="break-inside: avoid; page-break-inside: avoid">
-**Har du spørsmål?**<br/>
+##### Har du spørsmål?
 Du finner nyttig informasjon på [nav.no/familie](https://nav.no/familie).
 <br/>
 <br/>

--- a/src/test/resources/expected/klage-hjemsendt/fp_opphevet_tilbakekreving_nb.txt
+++ b/src/test/resources/expected/klage-hjemsendt/fp_opphevet_tilbakekreving_nb.txt
@@ -15,23 +15,19 @@ Fødselsnummer: 300220 12345
 </p>
 Vi kan ikke vurdere saken om tilbakebetaling av foreldrepenger fordi vi mangler opplysninger. Derfor har vi opphevet vedtaket og sendt saken din tilbake til NAV Familie- og pensjonsytelser. De skal behandle saken på nytt.
 Informasjon om saksbehandlingstid finner du på nav.no.
-<br/>
-<br/>
-**Dette har vi lagt vekt på i vurderingen vår**
-<br/>
+##### Dette har vi lagt vekt på i vurderingen vår
 FRITEKST
-<br/>
 <br/>
 Du kan ikke klage på denne beslutningen. Dette følger av forvaltningsloven §§ 2 og 28.
 Har du nye opplysninger eller ønsker å uttale deg, kan du sende dette via [nav.no/ettersendelser](https://nav.no/ettersendelser) innen 14. juni 2021.
 <br/>
-**Du har rett til innsyn**<br/>
+##### Du har rett til innsyn
 På [nav.no/dittnav](https://nav.no/dittnav) kan du se dokumentene i saken din.
 <br/>
 <br/>
 <br/>
 <div style="break-inside: avoid; page-break-inside: avoid">
-**Har du spørsmål?**<br/>
+##### Har du spørsmål?
 Du finner nyttig informasjon på [nav.no/familie](https://nav.no/familie).
 <br/>
 <br/>

--- a/src/test/resources/expected/klage-hjemsendt/fp_opphevet_tilbakekreving_nn.txt
+++ b/src/test/resources/expected/klage-hjemsendt/fp_opphevet_tilbakekreving_nn.txt
@@ -15,23 +15,19 @@ Fødselsnummer: 300220 12345
 </p>
 Vi kan ikkje vurdere saka om tilbakebetaling av foreldrepengar fordi vi manglar opplysningar. Derfor har vi oppheva vedtaket og sendt saka di tilbake til NAV Familie- og pensjonsytelser. Dei skal behandle søknaden på nytt.
 Informasjon om saksbehandlingstid finn du på nav.no.
-<br/>
-<br/>
-**Dette har vi lagt vekt på i vurderinga vår**
-<br/>
+##### Dette har vi lagt vekt på i vurderinga vår
 FRITEKST
-<br/>
 <br/>
 Du kan ikkje klage på denne avgjerda. Dette følgjer av forvaltningslova §§ 2 og 28.
 Har du nye opplysningar eller ønskjer å uttale deg, kan du sende dette via [nav.no/ettersendelser](https://nav.no/ettersendelser) innan 14. juni 2021.
 <br/>
-**Du har rett til innsyn**<br/>
+##### Du har rett til innsyn
 På [nav.no/dittnav](https://nav.no/dittnav) kan du sjå dokumenta i saka di.
 <br/>
 <br/>
 <br/>
 <div style="break-inside: avoid; page-break-inside: avoid">
-**Har du spørsmål?**<br/>
+##### Har du spørsmål?
 Du finn nyttig informasjon på [nav.no/familie](https://nav.no/familie).
 <br/>
 <br/>

--- a/src/test/resources/expected/klage-omgjort/es_nfp_tilbakekreving_nb.txt
+++ b/src/test/resources/expected/klage-omgjort/es_nfp_tilbakekreving_nb.txt
@@ -14,37 +14,28 @@ Fødselsnummer: 300220 12345
 <br/>
 </p>
 Etter at du klaget har vi vurdert saken din på nytt. Vi har kommet fram til at vedtaket ditt må gjøres om.
-**Dette har vi lagt vekt på i vurderingen vår**
-<br/>
+##### Dette har vi lagt vekt på i vurderingen vår
 FRITEKST
 <br/>
-<br/>
-**Du må melde fra om endringer**
-<br/>
+##### Du må melde fra om endringer
 Dersom det skjer endringer som kan ha betydning for stønaden du får utbetalt, må du straks melde fra til NAV. Du finner mer informasjon på [nav.no/rettogplikt](https://nav.no/rettogplikt).
-<br/>
-**Skatt**
-<br/>
+##### Skatt
 Beløpet du skal betale tilbake er redusert med den skatten som ble trukket da du fikk utbetalingen. NAV får skatten tilbake gjennom et oppgjør med Skatteetaten.
 NAV gir opplysninger til Skatteetaten. Skatteetaten vil vurdere om det er grunnlag for å endre skatteoppgjør.
-<br/>
-<br/>
-**Hvordan betale tilbake pengene du skylder**
-<br/>
+##### Hvordan betale tilbake pengene du skylder
 NAV Innkreving vil korrigere beløpet du skal betale tilbake. Du finner mer informasjon på [nav.no/innkreving](https://nav.no/innkreving).
 <br/>
-**Du har rett til å klage**
-<br/>
+##### Du har rett til å klage
 Du kan klage innen 6 uker fra den datoen du mottok vedtaket. Du finner skjema og informasjon på [nav.no/klage](https://nav.no/klage).
 Du må som hovedregel begynne å betale beløpet tilbake, selv om du klager på dette vedtaket. Dette følger av forvaltningsloven § 42. Vi vil betale tilbake pengene du har betalt inn, om du får vedtak om at du ikke trengte å betale tilbake hele eller deler av beløpet du skyldte.
 <br/>
-**Du har rett til innsyn**<br/>
+##### Du har rett til innsyn
 På [nav.no/dittnav](https://nav.no/dittnav) kan du se dokumentene i saken din.
 <br/>
 <br/>
 <br/>
 <div style="break-inside: avoid; page-break-inside: avoid">
-**Har du spørsmål?**<br/>
+##### Har du spørsmål?
 Du finner nyttig informasjon på [nav.no/familie](https://nav.no/familie).
 <br/>
 <br/>

--- a/src/test/resources/expected/klage-omgjort/fp_ka_tilbakekreving_nb.txt
+++ b/src/test/resources/expected/klage-omgjort/fp_ka_tilbakekreving_nb.txt
@@ -14,37 +14,28 @@ Fødselsnummer: 300220 12345
 <br/>
 </p>
 Etter at du klaget har vi vurdert saken din på nytt. Vi har kommet fram til at vedtaket til NAV Familie- og pensjonsytelser må gjøres om.
-**Dette har vi lagt vekt på i vurderingen vår**
-<br/>
+##### Dette har vi lagt vekt på i vurderingen vår
 FRITEKST
 <br/>
-<br/>
-**Du må melde fra om endringer**
-<br/>
+##### Du må melde fra om endringer
 Dersom det skjer endringer som kan ha betydning for stønaden du får utbetalt, må du straks melde fra til NAV. Du finner mer informasjon på [nav.no/rettogplikt](https://nav.no/rettogplikt).
-<br/>
-**Skatt**
-<br/>
+##### Skatt
 Beløpet du skal betale tilbake er redusert med den skatten som ble trukket da du fikk utbetalingen. NAV får skatten tilbake gjennom et oppgjør med Skatteetaten.
 NAV gir opplysninger til Skatteetaten. Skatteetaten vil vurdere om det er grunnlag for å endre skatteoppgjør.
-<br/>
-<br/>
-**Hvordan betale tilbake pengene du skylder**
-<br/>
+##### Hvordan betale tilbake pengene du skylder
 NAV Innkreving vil korrigere beløpet du skal betale tilbake. Du finner mer informasjon på [nav.no/innkreving](https://nav.no/innkreving).
 <br/>
-**Du har rett til å anke**
-<br/>
+##### Du har rett til å anke
 Du kan anke vedtaket til Trygderetten. Fristen er 6 uker fra den datoen vedtaket kom fram til deg.
 Klagerettighetene dine og skjema for klage/anke finner du på [nav.no/klage](https://nav.no/klage).
 <br/>
-**Du har rett til innsyn**<br/>
+##### Du har rett til innsyn
 På [nav.no/dittnav](https://nav.no/dittnav) kan du se dokumentene i saken din.
 <br/>
 <br/>
 <br/>
 <div style="break-inside: avoid; page-break-inside: avoid">
-**Har du spørsmål?**<br/>
+##### Har du spørsmål?
 Du finner nyttig informasjon på [nav.no/familie](https://nav.no/familie).
 <br/>
 <br/>

--- a/src/test/resources/expected/klage-omgjort/fp_ka_tilbakekreving_nn.txt
+++ b/src/test/resources/expected/klage-omgjort/fp_ka_tilbakekreving_nn.txt
@@ -14,37 +14,28 @@ Fødselsnummer: 300220 12345
 <br/>
 </p>
 Etter at du klaga, har vi vurdert saka di på nytt. Vi har kome fram til at vedtaket til NAV Familie- og pensjonsytelser må gjerast om.
-**Dette har vi lagt vekt på i vurderinga vår**
-<br/>
+##### Dette har vi lagt vekt på i vurderinga vår
 FRITEKST
 <br/>
-<br/>
-**Du må melde frå om endringar**
-<br/>
+##### Du må melde frå om endringar
 Dersom det skjer endringar som kan få følgjer for stønaden du får betalt ut, må du melde frå til NAV med ein gong. Du finn meir informasjon på [nav.no/rettogplikt](https://nav.no/rettogplikt).
-<br/>
-**Skatt**
-<br/>
+##### Skatt
 Beløpet du skal betale tilbake, er redusert med den skatten som blei trekt då du fekk utbetalinga. NAV får skatten tilbake gjennom eit oppgjer med Skatteetaten.
 NAV gjev opplysningar til Skatteetaten. Skatteetaten vil vurdere om det er grunnlag for å endre skatteoppgjer.
-<br/>
-<br/>
-**Korleis betale tilbake pengane du skuldar**
-<br/>
+##### Korleis betale tilbake pengane du skuldar
 NAV Innkrevjing vil korrigere beløpet du skal betale tilbake. Du finn meir informasjon på [nav.no/innkreving](https://nav.no/innkreving).
 <br/>
-**Du har rett til å anke**
-<br/>
+##### Du har rett til å anke
 Du kan anke vedtaket til Trygderetten. Fristen er 6 veker frå den datoen vedtaket kom fram til deg.
 Klagerettane dine og skjema for klage/anke finn du på [nav.no/klage](https://nav.no/klage).
 <br/>
-**Du har rett til innsyn**<br/>
+##### Du har rett til innsyn
 På [nav.no/dittnav](https://nav.no/dittnav) kan du sjå dokumenta i saka di.
 <br/>
 <br/>
 <br/>
 <div style="break-inside: avoid; page-break-inside: avoid">
-**Har du spørsmål?**<br/>
+##### Har du spørsmål?
 Du finn nyttig informasjon på [nav.no/familie](https://nav.no/familie).
 <br/>
 <br/>

--- a/src/test/resources/expected/klage-omgjort/svp_nfp_ikke-tilbakekreving_nb.txt
+++ b/src/test/resources/expected/klage-omgjort/svp_nfp_ikke-tilbakekreving_nb.txt
@@ -14,26 +14,22 @@ Fødselsnummer: 300220 12345
 <br/>
 </p>
 Etter at du klaget har vi vurdert saken din på nytt. Vi har kommet fram til at vedtaket ditt må gjøres om.
-**Dette har vi lagt vekt på i vurderingen vår**
-<br/>
+##### Dette har vi lagt vekt på i vurderingen vår
 FRITEKST
 <br/>
-<br/>
-**Du må melde fra om endringer**
-<br/>
+##### Du må melde fra om endringer
 Dersom det skjer endringer som kan ha betydning for stønaden du får utbetalt, må du straks melde fra til NAV. Du finner mer informasjon på [nav.no/rettogplikt](https://nav.no/rettogplikt).
 <br/>
-**Du har rett til å klage**
-<br/>
+##### Du har rett til å klage
 Du kan klage innen 6 uker fra den datoen du mottok vedtaket. Du finner skjema og informasjon på [nav.no/klage](https://nav.no/klage).
 <br/>
-**Du har rett til innsyn**<br/>
+##### Du har rett til innsyn
 På [nav.no/dittnav](https://nav.no/dittnav) kan du se dokumentene i saken din.
 <br/>
 <br/>
 <br/>
 <div style="break-inside: avoid; page-break-inside: avoid">
-**Har du spørsmål?**<br/>
+##### Har du spørsmål?
 Du finner nyttig informasjon på [nav.no/familie](https://nav.no/familie).
 <br/>
 <br/>

--- a/src/test/resources/expected/klage-oversendt/fp_tilbakekreving_nb.txt
+++ b/src/test/resources/expected/klage-oversendt/fp_tilbakekreving_nb.txt
@@ -15,22 +15,18 @@ Fødselsnummer: 300220 12345
 </p>
 Vi har mottatt klagen din på vedtaket om tilbakebetaling av foreldrepenger 3. mai 2021, og kommet fram til at det ikke endres. NAV Klageinstans skal derfor vurdere saken din på nytt.
 Informasjon om saksbehandlingstid finner du på nav.no.
-<br/>
-<br/>
-**Dette har vi lagt vekt på i vurderingen vår**
-<br/>
+##### Dette har vi lagt vekt på i vurderingen vår
 FRITEKST
-<br/>
 <br/>
 Har du nye opplysninger eller ønsker å uttale deg, kan du sende dette via [nav.no/klage](https://nav.no/klage). Velg NAV-enhet: NAV Klageinstans Midt-Norge.
 <br/>
-**Du har rett til innsyn**<br/>
+##### Du har rett til innsyn
 På [nav.no/dittnav](https://nav.no/dittnav) kan du se dokumentene i saken din.
 <br/>
 <br/>
 <br/>
 <div style="break-inside: avoid; page-break-inside: avoid">
-**Har du spørsmål?**<br/>
+##### Har du spørsmål?
 Du finner nyttig informasjon på [nav.no/familie](https://nav.no/familie).
 <br/>
 <br/>

--- a/src/test/resources/expected/klage-oversendt/fp_tilbakekreving_nn.txt
+++ b/src/test/resources/expected/klage-oversendt/fp_tilbakekreving_nn.txt
@@ -15,22 +15,18 @@ Fødselsnummer: 300220 12345
 </p>
 Vi har fått klaga di på vedtaket om tilbakebetaling av foreldrepengar 3. mai 2021, og kome fram til at det ikkje blir endra. NAV Klageinstans skal derfor vurdere saka di på nytt.
 Informasjon om saksbehandlingstid finn du på nav.no.
-<br/>
-<br/>
-**Dette har vi lagt vekt på i vurderinga vår**
-<br/>
+##### Dette har vi lagt vekt på i vurderinga vår
 FRITEKST
-<br/>
 <br/>
 Har du nye opplysningar eller ønskjer å uttale deg, kan du sende dette via [nav.no/klage](https://nav.no/klage). Vel NAV-eining: NAV Klageinstans Midt-Noreg.
 <br/>
-**Du har rett til innsyn**<br/>
+##### Du har rett til innsyn
 På [nav.no/dittnav](https://nav.no/dittnav) kan du sjå dokumenta i saka di.
 <br/>
 <br/>
 <br/>
 <div style="break-inside: avoid; page-break-inside: avoid">
-**Har du spørsmål?**<br/>
+##### Har du spørsmål?
 Du finn nyttig informasjon på [nav.no/familie](https://nav.no/familie).
 <br/>
 <br/>

--- a/src/test/resources/expected/klage-oversendt/svp_ikke-tilbakekreving_nb.txt
+++ b/src/test/resources/expected/klage-oversendt/svp_ikke-tilbakekreving_nb.txt
@@ -15,22 +15,18 @@ Fødselsnummer: 300220 12345
 </p>
 Vi har mottatt klagen din på vedtaket om svangerskapspenger 3. mai 2021, og kommet fram til at det ikke endres. NAV Klageinstans skal derfor vurdere saken din på nytt.
 Informasjon om saksbehandlingstid finner du på nav.no.
-<br/>
-<br/>
-**Dette har vi lagt vekt på i vurderingen vår**
-<br/>
+##### Dette har vi lagt vekt på i vurderingen vår
 FRITEKST
-<br/>
 <br/>
 Har du nye opplysninger eller ønsker å uttale deg, kan du sende dette via [nav.no/klage](https://nav.no/klage). Velg NAV-enhet: NAV Klageinstans Midt-Norge.
 <br/>
-**Du har rett til innsyn**<br/>
+##### Du har rett til innsyn
 På [nav.no/dittnav](https://nav.no/dittnav) kan du se dokumentene i saken din.
 <br/>
 <br/>
 <br/>
 <div style="break-inside: avoid; page-break-inside: avoid">
-**Har du spørsmål?**<br/>
+##### Har du spørsmål?
 Du finner nyttig informasjon på [nav.no/familie](https://nav.no/familie).
 <br/>
 <br/>

--- a/src/test/resources/expected/klage-stadfestet/es_ikke-tilbakekreving_nb.txt
+++ b/src/test/resources/expected/klage-stadfestet/es_ikke-tilbakekreving_nb.txt
@@ -14,24 +14,20 @@ Fødselsnummer: 300220 12345
 <br/>
 </p>
 Vi er enige i avgjørelsen om at du ikke har rett til engangsstønad. Derfor har vi ikke endret vedtaket du klaget på.
-<br/>
-**Dette har vi lagt vekt på i vurderingen vår**
-<br/>
+##### Dette har vi lagt vekt på i vurderingen vår
 FRITEKST
 <br/>
-<br/>
-**Du har rett til å anke**
-<br/>
+##### Du har rett til å anke
 Du kan anke vedtaket til Trygderetten. Fristen er 6 uker fra den datoen vedtaket kom fram til deg.
 Klagerettighetene dine og skjema for klage/anke finner du på [nav.no/klage](https://nav.no/klage).
 <br/>
-**Du har rett til innsyn**<br/>
+##### Du har rett til innsyn
 På [nav.no/dittnav](https://nav.no/dittnav) kan du se dokumentene i saken din.
 <br/>
 <br/>
 <br/>
 <div style="break-inside: avoid; page-break-inside: avoid">
-**Har du spørsmål?**<br/>
+##### Har du spørsmål?
 Du finner nyttig informasjon på [nav.no/familie](https://nav.no/familie).
 <br/>
 <br/>

--- a/src/test/resources/expected/klage-stadfestet/fp_tilbakekreving_nb.txt
+++ b/src/test/resources/expected/klage-stadfestet/fp_tilbakekreving_nb.txt
@@ -14,24 +14,20 @@ Fødselsnummer: 300220 12345
 <br/>
 </p>
 Vi er enige i avgjørelsen til NAV Familie- og pensjonsytelser. Derfor har vi ikke endret vedtaket du klaget på.
-<br/>
-**Dette har vi lagt vekt på i vurderingen vår**
-<br/>
+##### Dette har vi lagt vekt på i vurderingen vår
 FRITEKST
 <br/>
-<br/>
-**Du har rett til å anke**
-<br/>
+##### Du har rett til å anke
 Du kan anke vedtaket til Trygderetten. Fristen er 6 uker fra den datoen vedtaket kom fram til deg.
 Klagerettighetene dine og skjema for klage/anke finner du på [nav.no/klage](https://nav.no/klage).
 <br/>
-**Du har rett til innsyn**<br/>
+##### Du har rett til innsyn
 På [nav.no/dittnav](https://nav.no/dittnav) kan du se dokumentene i saken din.
 <br/>
 <br/>
 <br/>
 <div style="break-inside: avoid; page-break-inside: avoid">
-**Har du spørsmål?**<br/>
+##### Har du spørsmål?
 Du finner nyttig informasjon på [nav.no/familie](https://nav.no/familie).
 <br/>
 <br/>

--- a/src/test/resources/expected/klage-stadfestet/fp_tilbakekreving_nn.txt
+++ b/src/test/resources/expected/klage-stadfestet/fp_tilbakekreving_nn.txt
@@ -14,24 +14,20 @@ Fødselsnummer: 300220 12345
 <br/>
 </p>
 Vi er samde i avgjerda til NAV Familie- og pensjonsytelser. Derfor har vi ikkje endra vedtaket du klaga på.
-<br/>
-**Dette har vi lagt vekt på i vurderinga vår**
-<br/>
+##### Dette har vi lagt vekt på i vurderinga vår
 FRITEKST
 <br/>
-<br/>
-**Du har rett til å anke**
-<br/>
+##### Du har rett til å anke
 Du kan anke vedtaket til Trygderetten. Fristen er 6 veker frå den datoen vedtaket kom fram til deg.
 Klagerettane dine og skjema for klage/anke finn du på [nav.no/klage](https://nav.no/klage).
 <br/>
-**Du har rett til innsyn**<br/>
+##### Du har rett til innsyn
 På [nav.no/dittnav](https://nav.no/dittnav) kan du sjå dokumenta i saka di.
 <br/>
 <br/>
 <br/>
 <div style="break-inside: avoid; page-break-inside: avoid">
-**Har du spørsmål?**<br/>
+##### Har du spørsmål?
 Du finn nyttig informasjon på [nav.no/familie](https://nav.no/familie).
 <br/>
 <br/>

--- a/src/test/resources/expected/varsel-revurdering/varsel-revurdering_es_ANNET_en.txt
+++ b/src/test/resources/expected/varsel-revurdering/varsel-revurdering_es_ANNET_en.txt
@@ -24,23 +24,20 @@ FRITEKST LINJE 2</p>
 
 Your duty to give information is according to sections 21‑3 og 21‑4 of the National Insurance Act.
 <br/>
-<br/>
-
-**The decision about your lump-sum grant can be reversed**
-<br/>
+##### The decision about your lump-sum grant can be reversed
 We will consider your case again after the deadline has been reached. If you are not entitled to the lump-sum grant, you can be asked to repay the money back.
 
 You can send us information at [nav.no/ettersendelser](https://nav.no/ettersendelser).
 <br/>
 <br/>
-**You have right of access**<br/>
+##### You have right of access
 Go to [nav.no/dittnav](https://nav.no/dittnav) to see the documents in your case.
 <br/>
 <br/>
 <br/>
 <div style="break-inside: avoid; page-break-inside: avoid">
 
-**Do you have questions?**<br/>
+##### Do you have questions?
 You will find useful information at [nav.no/familie](https://nav.no/familie).
 <br/>
 <br/>

--- a/src/test/resources/expected/varsel-revurdering/varsel-revurdering_es_ANNET_nb.txt
+++ b/src/test/resources/expected/varsel-revurdering/varsel-revurdering_es_ANNET_nb.txt
@@ -24,23 +24,20 @@ FRITEKST LINJE 2</p>
 
 Opplysningsplikten går fram av folketrygdloven §§ 21-3 og 21-4.
 <br/>
-<br/>
-
-**Vedtaket ditt om engangsstønad kan bli omgjort**
-<br/>
+##### Vedtaket ditt om engangsstønad kan bli omgjort
 Vi vil vurdere saken din på nytt når fristen er gått ut. Dersom du ikke har hatt rett til engangsstønad, kan du bli nødt til å betale tilbake pengene.
 
 Du sender dokumentasjonen til oss på [nav.no/ettersendelser](https://nav.no/ettersendelser).
 <br/>
 <br/>
-**Du har rett til innsyn**<br/>
+##### Du har rett til innsyn
 På [nav.no/dittnav](https://nav.no/dittnav) kan du se dokumentene i saken din.
 <br/>
 <br/>
 <br/>
 <div style="break-inside: avoid; page-break-inside: avoid">
 
-**Har du spørsmål?**<br/>
+##### Har du spørsmål?
 Du finner nyttig informasjon på [nav.no/familie](https://nav.no/familie).
 <br/>
 <br/>

--- a/src/test/resources/expected/varsel-revurdering/varsel-revurdering_es_BARNIKKEREG_en.txt
+++ b/src/test/resources/expected/varsel-revurdering/varsel-revurdering_es_BARNIKKEREG_en.txt
@@ -25,23 +25,20 @@ You are entitled to make a statement before the given deadline.
 
 Your duty to give information is according to sections 21‑3 og 21‑4 of the National Insurance Act.
 <br/>
-<br/>
-
-**The decision about your lump-sum grant can be reversed**
-<br/>
+##### The decision about your lump-sum grant can be reversed
 We will consider your case again after the deadline has been reached. If you are not entitled to the lump-sum grant, you can be asked to repay the money back.
 
 You can send us information at [nav.no/ettersendelser](https://nav.no/ettersendelser).
 <br/>
 <br/>
-**You have right of access**<br/>
+##### You have right of access
 Go to [nav.no/dittnav](https://nav.no/dittnav) to see the documents in your case.
 <br/>
 <br/>
 <br/>
 <div style="break-inside: avoid; page-break-inside: avoid">
 
-**Do you have questions?**<br/>
+##### Do you have questions?
 You will find useful information at [nav.no/familie](https://nav.no/familie).
 <br/>
 <br/>

--- a/src/test/resources/expected/varsel-revurdering/varsel-revurdering_es_BARNIKKEREG_nb.txt
+++ b/src/test/resources/expected/varsel-revurdering/varsel-revurdering_es_BARNIKKEREG_nb.txt
@@ -25,23 +25,20 @@ Du har også rett til å uttale deg om saken innen fristen som er oppgitt.
 
 Opplysningsplikten går fram av folketrygdloven §§ 21-3 og 21-4.
 <br/>
-<br/>
-
-**Vedtaket ditt om engangsstønad kan bli omgjort**
-<br/>
+##### Vedtaket ditt om engangsstønad kan bli omgjort
 Vi vil vurdere saken din på nytt når fristen er gått ut. Dersom du ikke har hatt rett til engangsstønad, kan du bli nødt til å betale tilbake pengene.
 
 Du sender dokumentasjonen til oss på [nav.no/ettersendelser](https://nav.no/ettersendelser).
 <br/>
 <br/>
-**Du har rett til innsyn**<br/>
+##### Du har rett til innsyn
 På [nav.no/dittnav](https://nav.no/dittnav) kan du se dokumentene i saken din.
 <br/>
 <br/>
 <br/>
 <div style="break-inside: avoid; page-break-inside: avoid">
 
-**Har du spørsmål?**<br/>
+##### Har du spørsmål?
 Du finner nyttig informasjon på [nav.no/familie](https://nav.no/familie).
 <br/>
 <br/>

--- a/src/test/resources/expected/varsel-revurdering/varsel-revurdering_fp_AKTIVITET_flere_opplysninger_2barn_nb.txt
+++ b/src/test/resources/expected/varsel-revurdering/varsel-revurdering_fp_AKTIVITET_flere_opplysninger_2barn_nb.txt
@@ -35,23 +35,20 @@ Du sender uttalelsen din ved å logge deg inn på [nav.no/dittnav](https://nav.n
 
 Opplysningsplikten går fram av folketrygdloven §§ 21-3 og 21-4.
 <br/>
-<br/>
-
-**Vedtaket ditt om foreldrepenger kan bli omgjort**
-<br/>
+##### Vedtaket ditt om foreldrepenger kan bli omgjort
 Vi vil vurdere saken din på nytt når fristen er gått ut. Dersom du ikke har hatt rett til foreldrepenger, kan du bli nødt til å betale tilbake pengene.
 
 Du sender dokumentasjonen til oss på [nav.no/ettersendelser](https://nav.no/ettersendelser).
 <br/>
 <br/>
-**Du har rett til innsyn**<br/>
+##### Du har rett til innsyn
 På [nav.no/dittnav](https://nav.no/dittnav) kan du se dokumentene i saken din.
 <br/>
 <br/>
 <br/>
 <div style="break-inside: avoid; page-break-inside: avoid">
 
-**Har du spørsmål?**<br/>
+##### Har du spørsmål?
 Du finner nyttig informasjon på [nav.no/familie](https://nav.no/familie).
 <br/>
 <br/>

--- a/src/test/resources/expected/varsel-revurdering/varsel-revurdering_fp_AKTIVITET_flere_opplysninger_2barn_nn.txt
+++ b/src/test/resources/expected/varsel-revurdering/varsel-revurdering_fp_AKTIVITET_flere_opplysninger_2barn_nn.txt
@@ -35,23 +35,20 @@ Du sender uttalen din ved å logge deg inn på [nav.no/dittnav](https://nav.no/d
 
 Opplysningsplikta går fram av folketrygdlova §§ 21-3 og 21-4.
 <br/>
-<br/>
-
-**Vedtaket ditt om foreldrepengar kan bli gjort om**
-<br/>
+##### Vedtaket ditt om foreldrepengar kan bli gjort om
 Vi vil vurdere saka di på nytt når fristen er gått ut. Dersom du ikkje har hatt rett til foreldrepengar, kan du bli nøydd til å betale tilbake pengane.
 
 Du sender dokumentasjonen til oss på [nav.no/ettersendelser](https://nav.no/ettersendelser).
 <br/>
 <br/>
-**Du har rett til innsyn**<br/>
+##### Du har rett til innsyn
 På [nav.no/dittnav](https://nav.no/dittnav) kan du sjå dokumenta i saka di.
 <br/>
 <br/>
 <br/>
 <div style="break-inside: avoid; page-break-inside: avoid">
 
-**Har du spørsmål?**<br/>
+##### Har du spørsmål?
 Du finn nyttig informasjon på [nav.no/familie](https://nav.no/familie).
 <br/>
 <br/>

--- a/src/test/resources/expected/varsel-revurdering/varsel-revurdering_fp_ANNET_nb.txt
+++ b/src/test/resources/expected/varsel-revurdering/varsel-revurdering_fp_ANNET_nb.txt
@@ -24,23 +24,20 @@ FRITEKST LINJE 2</p>
 
 Opplysningsplikten går fram av folketrygdloven §§ 21-3 og 21-4.
 <br/>
-<br/>
-
-**Vedtaket ditt om foreldrepenger kan bli omgjort**
-<br/>
+##### Vedtaket ditt om foreldrepenger kan bli omgjort
 Vi vil vurdere saken din på nytt når fristen er gått ut. Dersom du ikke har hatt rett til foreldrepenger, kan du bli nødt til å betale tilbake pengene.
 
 Du sender dokumentasjonen til oss på [nav.no/ettersendelser](https://nav.no/ettersendelser).
 <br/>
 <br/>
-**Du har rett til innsyn**<br/>
+##### Du har rett til innsyn
 På [nav.no/dittnav](https://nav.no/dittnav) kan du se dokumentene i saken din.
 <br/>
 <br/>
 <br/>
 <div style="break-inside: avoid; page-break-inside: avoid">
 
-**Har du spørsmål?**<br/>
+##### Har du spørsmål?
 Du finner nyttig informasjon på [nav.no/familie](https://nav.no/familie).
 <br/>
 <br/>

--- a/src/test/resources/expected/varsel-revurdering/varsel-revurdering_fp_IKKEOPPTJENT_ikke_flere_opplysninger_nb.txt
+++ b/src/test/resources/expected/varsel-revurdering/varsel-revurdering_fp_IKKEOPPTJENT_ikke_flere_opplysninger_nb.txt
@@ -21,23 +21,20 @@ Vi har fått opplysninger om at inntekten din var lavere enn et halvt grunnbelø
 
 Opplysningsplikten går fram av folketrygdloven §§ 21-3 og 21-4.
 <br/>
-<br/>
-
-**Vedtaket ditt om foreldrepenger kan bli omgjort**
-<br/>
+##### Vedtaket ditt om foreldrepenger kan bli omgjort
 Vi vil vurdere saken din på nytt når fristen er gått ut. Dersom du ikke har hatt rett til foreldrepenger, kan du bli nødt til å betale tilbake pengene.
 
 Du sender dokumentasjonen til oss på [nav.no/ettersendelser](https://nav.no/ettersendelser).
 <br/>
 <br/>
-**Du har rett til innsyn**<br/>
+##### Du har rett til innsyn
 På [nav.no/dittnav](https://nav.no/dittnav) kan du se dokumentene i saken din.
 <br/>
 <br/>
 <br/>
 <div style="break-inside: avoid; page-break-inside: avoid">
 
-**Har du spørsmål?**<br/>
+##### Har du spørsmål?
 Du finner nyttig informasjon på [nav.no/familie](https://nav.no/familie).
 <br/>
 <br/>

--- a/src/test/resources/expected/varsel-revurdering/varsel-revurdering_fp_JOBBFULLTID_nb.txt
+++ b/src/test/resources/expected/varsel-revurdering/varsel-revurdering_fp_JOBBFULLTID_nb.txt
@@ -19,20 +19,18 @@ Du kan ikke jobbe heltid og samtidig få foreldrepenger. Arbeider du deltid, kan
 Du kan søke om å endre perioden din på [nav.no](https://nav.no/). Ønsker du å uttale deg kan du gjøre det ved å logge deg inn på [nav.no/dittnav](https://nav.no/dittnav) og velge «Send beskjed til NAV».
 Opplysningsplikten går fram av folketrygdloven §§ 21-3 og 21-4.
 <br/>
-<br/>
-**Vedtaket ditt om foreldrepenger kan bli omgjort**
-<br/>
+##### Vedtaket ditt om foreldrepenger kan bli omgjort
 Vi vil vurdere saken din på nytt når fristen er gått ut. Dersom du ikke har hatt rett til foreldrepenger, kan du bli nødt til å betale tilbake pengene.
 Du sender dokumentasjonen til oss på [nav.no/ettersendelser](https://nav.no/ettersendelser).
 <br/>
 <br/>
-**Du har rett til innsyn**<br/>
+##### Du har rett til innsyn
 På [nav.no/dittnav](https://nav.no/dittnav) kan du se dokumentene i saken din.
 <br/>
 <br/>
 <br/>
 <div style="break-inside: avoid; page-break-inside: avoid">
-**Har du spørsmål?**<br/>
+##### Har du spørsmål?
 Du finner nyttig informasjon på [nav.no/familie](https://nav.no/familie).
 <br/>
 <br/>

--- a/src/test/resources/expected/varsel-revurdering/varsel-revurdering_fp_JOBBFULLTID_nn.txt
+++ b/src/test/resources/expected/varsel-revurdering/varsel-revurdering_fp_JOBBFULLTID_nn.txt
@@ -19,20 +19,18 @@ Du kan ikkje jobbe heiltid og samtidig få foreldrepengar. Arbeider du deltid, k
 Du kan søkje om å endre perioden din på [nav.no](https://nav.no/). Ønskjer du å uttale deg kan du gjere det ved å logge deg inn på [nav.no/dittnav](https://nav.no/dittnav) og velje «Send beskjed til NAV».
 Opplysningsplikta går fram av folketrygdlova §§ 21-3 og 21-4.
 <br/>
-<br/>
-**Vedtaket ditt om foreldrepengar kan bli gjort om**
-<br/>
+##### Vedtaket ditt om foreldrepengar kan bli gjort om
 Vi vil vurdere saka di på nytt når fristen er gått ut. Dersom du ikkje har hatt rett til foreldrepengar, kan du bli nøydd til å betale tilbake pengane.
 Du sender dokumentasjonen til oss på [nav.no/ettersendelser](https://nav.no/ettersendelser).
 <br/>
 <br/>
-**Du har rett til innsyn**<br/>
+##### Du har rett til innsyn
 På [nav.no/dittnav](https://nav.no/dittnav) kan du sjå dokumenta i saka di.
 <br/>
 <br/>
 <br/>
 <div style="break-inside: avoid; page-break-inside: avoid">
-**Har du spørsmål?**<br/>
+##### Har du spørsmål?
 Du finn nyttig informasjon på [nav.no/familie](https://nav.no/familie).
 <br/>
 <br/>

--- a/src/test/resources/expected/varsel-revurdering/varsel-revurdering_svp_JOBB6MND_nb.txt
+++ b/src/test/resources/expected/varsel-revurdering/varsel-revurdering_svp_JOBB6MND_nb.txt
@@ -20,23 +20,20 @@ Vi har fått nye opplysninger som viser at du ikke har jobbet fire uker før du 
 
 Opplysningsplikten går fram av folketrygdloven §§ 21-3 og 21-4.
 <br/>
-<br/>
-
-**Vedtaket ditt om svangerskapspenger kan bli omgjort**
-<br/>
+##### Vedtaket ditt om svangerskapspenger kan bli omgjort
 Vi vil vurdere saken din på nytt når fristen er gått ut. Dersom du ikke har hatt rett til svangerskapspenger, kan du bli nødt til å betale tilbake pengene.
 
 Du sender dokumentasjonen til oss på [nav.no/ettersendelser](https://nav.no/ettersendelser).
 <br/>
 <br/>
-**Du har rett til innsyn**<br/>
+##### Du har rett til innsyn
 På [nav.no/dittnav](https://nav.no/dittnav) kan du se dokumentene i saken din.
 <br/>
 <br/>
 <br/>
 <div style="break-inside: avoid; page-break-inside: avoid">
 
-**Har du spørsmål?**<br/>
+##### Har du spørsmål?
 Du finner nyttig informasjon på [nav.no/familie](https://nav.no/familie).
 <br/>
 <br/>

--- a/src/test/resources/expected/varsel-revurdering/varsel-revurdering_svp_JOBBFULLTID_nb.txt
+++ b/src/test/resources/expected/varsel-revurdering/varsel-revurdering_svp_JOBBFULLTID_nb.txt
@@ -26,23 +26,20 @@ Du kan søke om å endre perioden din på [nav.no](https://nav.no/). Ønsker du 
 
 Opplysningsplikten går fram av folketrygdloven §§ 21-3 og 21-4.
 <br/>
-<br/>
-
-**Vedtaket ditt om svangerskapspenger kan bli omgjort**
-<br/>
+##### Vedtaket ditt om svangerskapspenger kan bli omgjort
 Vi vil vurdere saken din på nytt når fristen er gått ut. Dersom du ikke har hatt rett til svangerskapspenger, kan du bli nødt til å betale tilbake pengene.
 
 Du sender dokumentasjonen til oss på [nav.no/ettersendelser](https://nav.no/ettersendelser).
 <br/>
 <br/>
-**Du har rett til innsyn**<br/>
+##### Du har rett til innsyn
 På [nav.no/dittnav](https://nav.no/dittnav) kan du se dokumentene i saken din.
 <br/>
 <br/>
 <br/>
 <div style="break-inside: avoid; page-break-inside: avoid">
 
-**Har du spørsmål?**<br/>
+##### Har du spørsmål?
 Du finner nyttig informasjon på [nav.no/familie](https://nav.no/familie).
 <br/>
 <br/>

--- a/src/test/resources/expected/varsel-revurdering/varsel-revurdering_svp_JOBBFULLTID_nn.txt
+++ b/src/test/resources/expected/varsel-revurdering/varsel-revurdering_svp_JOBBFULLTID_nn.txt
@@ -26,23 +26,20 @@ Du kan søkje om å endre perioden din på [nav.no](https://nav.no/). Ønskjer d
 
 Opplysningsplikta går fram av folketrygdlova §§ 21-3 og 21-4.
 <br/>
-<br/>
-
-**Vedtaket ditt om svangerskapspengar kan bli gjort om**
-<br/>
+##### Vedtaket ditt om svangerskapspengar kan bli gjort om
 Vi vil vurdere saka di på nytt når fristen er gått ut. Dersom du ikkje har hatt rett til svangerskapspengar, kan du bli nøydd til å betale tilbake pengane.
 
 Du sender dokumentasjonen til oss på [nav.no/ettersendelser](https://nav.no/ettersendelser).
 <br/>
 <br/>
-**Du har rett til innsyn**<br/>
+##### Du har rett til innsyn
 På [nav.no/dittnav](https://nav.no/dittnav) kan du sjå dokumenta i saka di.
 <br/>
 <br/>
 <br/>
 <div style="break-inside: avoid; page-break-inside: avoid">
 
-**Har du spørsmål?**<br/>
+##### Har du spørsmål?
 Du finn nyttig informasjon på [nav.no/familie](https://nav.no/familie).
 <br/>
 <br/>


### PR DESCRIPTION
… ** / bold, slik at det blir konsistent med overskriftene i fritekstfeltene. Dette gjør at vi unngår mange hardkodede linjeskift.