### PR TITLE
TFP-4778 Foreldrepenger innvilgelse

### DIFF
--- a/content/templates/foreldrepenger-innvilgelse/avslag_en.hbs
+++ b/content/templates/foreldrepenger-innvilgelse/avslag_en.hbs
@@ -9,6 +9,11 @@
 {{#each perioder}}
 {{~#unless innvilget}}
 {{#switch årsak}}
+{{#case "4095"}}
+{{#if morKanSøkeOmDagerFørFødsel}}
+{{>punkt}}The parental benefit period starts three weeks before the estimated date of delivery. You have not claimed parental benefit from {{periodeFom}} up to and including {{periodeTom}}. You will therefore lose {{#gt antallTapteDager 1}}these days{{else}}this day{{/gt}}. If you want to take out {{#gt antallTapteDager 1}}these days{{else}}this day{{/gt}}, you must apply for this on [nav.no/foreldrepenger](https://nav.no/foreldrepenger).
+{{/if}}
+{{/case}}
 {{#case "4077"}}
 {{>punkt}}You cannot postpone parental benefit from {{periodeFom}} up to and including {{periodeTom}} because you are receiving attendance allowance in this period.
 

--- a/content/templates/foreldrepenger-innvilgelse/avslag_nb.hbs
+++ b/content/templates/foreldrepenger-innvilgelse/avslag_nb.hbs
@@ -9,6 +9,11 @@
 {{#each perioder}}
 {{~#unless innvilget}}
 {{#switch årsak}}
+{{#case "4095"}}
+{{#if morKanSøkeOmDagerFørFødsel}}
+{{>punkt}}Perioden med foreldrepenger starter tre uker før termin. Du har ikke tatt ut foreldrepenger fra og med {{periodeFom}} til og med {{periodeTom}}. Derfor mister du {{#gt antallTapteDager 1}}disse dagene{{else}}denne dagen{{/gt}}. Dersom du ønsker å ta ut {{#gt antallTapteDager 1}}disse dagene{{else}}denne dagen{{/gt}}, må du søke om det på [nav.no/foreldrepenger](https://nav.no/foreldrepenger).
+{{/if}}
+{{/case}}
 {{#case "4077"}}
 {{>punkt}}Du kan ikke utsette foreldrepengene fra og med {{periodeFom}} til og med {{periodeTom}} fordi du får pleiepenger i denne perioden.
 

--- a/content/templates/foreldrepenger-innvilgelse/avslag_nn.hbs
+++ b/content/templates/foreldrepenger-innvilgelse/avslag_nn.hbs
@@ -9,6 +9,11 @@
 {{#each perioder}}
 {{~#unless innvilget}}
 {{#switch årsak}}
+{{#case "4095"}}
+{{#if morKanSøkeOmDagerFørFødsel}}
+{{>punkt}}Perioden med foreldrepengar startar tre veker før termin. Du har ikkje teke ut foreldrepengar frå og med {{periodeFom}} til og med {{periodeTom}}. Derfor mistar du {{#gt antallTapteDager 1}}disse dagane{{else}}denne dagen{{/gt}}. Dersom du ønskjer å ta ut {{#gt antallTapteDager 1}}disse dagane{{else}}denne dagen{{/gt}}, må du søkje om det på [nav.no/foreldrepenger](https://nav.no/foreldrepenger).
+{{/if}}
+{{/case}}
 {{#case "4077"}}
 {{>punkt}}Du kan ikkje utsetje foreldrepengane frå og med {{periodeFom}} til og med {{periodeTom}} fordi du får pleiepengar i denne perioden.
 

--- a/content/templates/foreldrepenger-innvilgelse/schema.json
+++ b/content/templates/foreldrepenger-innvilgelse/schema.json
@@ -361,6 +361,9 @@
     "kreverSammenhengendeUttak": {
       "type": "boolean"
     },
+    "morKanSøkeOmDagerFørFødsel": {
+      "type": "boolean"
+    },
     "perioder": {
       "type": "array",
       "items": { "$ref": "#/$defs/utbetalingsperiode" }

--- a/content/templates/foreldrepenger-innvilgelse/testdata/avslag/førstegangsbehandling_avslag.json
+++ b/content/templates/foreldrepenger-innvilgelse/testdata/avslag/førstegangsbehandling_avslag.json
@@ -46,6 +46,7 @@
   "prematurDager": 0,
   "antallDødeBarn": 0,
   "kreverSammenhengendeUttak": true,
+  "morKanSøkeOmDagerFørFødsel": true,
   "perioder": [
     {
       "innvilget": true,
@@ -55,6 +56,23 @@
       "periodeDagsats": 2209,
       "antallTapteDager": 0,
       "prioritertUtbetalingsgrad": 100,
+      "arbeidsforholdsliste": [
+        {
+          "arbeidsgiverNavn": "ARBEIDSGIVER AS",
+          "gradering": false,
+          "utbetalingsgrad": 100,
+          "prosentArbeid": 0,
+          "stillingsprosent": 100
+        }
+      ]
+    },
+    {
+      "innvilget": false,
+      "årsak": "4095",
+      "periodeFom": "15. april 2021",
+      "periodeTom": "18. august 2021",
+      "periodeDagsats": 2209,
+      "antallTapteDager": 5,
       "arbeidsforholdsliste": [
         {
           "arbeidsgiverNavn": "ARBEIDSGIVER AS",

--- a/content/templates/foreldrepenger-innvilgelse/testdata/forstegangsbehandling/automatisk_ingen_gradering_ingen_avslag.json
+++ b/content/templates/foreldrepenger-innvilgelse/testdata/forstegangsbehandling/automatisk_ingen_gradering_ingen_avslag.json
@@ -46,6 +46,7 @@
   "antallBarn": 1,
   "antallDødeBarn": 0,
   "kreverSammenhengendeUttak": true,
+  "morKanSøkeOmDagerFørFødsel": false,
   "prematurDager": 0,
   "perioder": [
     {

--- a/content/templates/foreldrepenger-innvilgelse/testdata/forstegangsbehandling/gradering_flere_arbgivere_og_gradering.json
+++ b/content/templates/foreldrepenger-innvilgelse/testdata/forstegangsbehandling/gradering_flere_arbgivere_og_gradering.json
@@ -50,6 +50,7 @@
   "prematurDager": 0,
   "antallDødeBarn": 0,
   "kreverSammenhengendeUttak": true,
+  "morKanSøkeOmDagerFørFødsel": false,
   "perioder": [
     {
       "innvilget": true,

--- a/content/templates/foreldrepenger-innvilgelse/testdata/forstegangsbehandling/med_avslag_periode.json
+++ b/content/templates/foreldrepenger-innvilgelse/testdata/forstegangsbehandling/med_avslag_periode.json
@@ -47,6 +47,7 @@
   "prematurDager": 0,
   "antallDødeBarn": 0,
   "kreverSammenhengendeUttak": true,
+  "morKanSøkeOmDagerFørFødsel": false,
   "perioder": [
     {
       "innvilget": true,

--- a/content/templates/foreldrepenger-innvilgelse/testdata/forstegangsbehandling/med_fritekst.json
+++ b/content/templates/foreldrepenger-innvilgelse/testdata/forstegangsbehandling/med_fritekst.json
@@ -51,6 +51,7 @@
   "prematurDager": 0,
   "antallDødeBarn": 0,
   "kreverSammenhengendeUttak": true,
+  "morKanSøkeOmDagerFørFødsel": false,
   "perioder": [
     {
       "innvilget": true,

--- a/content/templates/foreldrepenger-innvilgelse/testdata/utbetaling/førstegangsbehandling_full_refusjon.json
+++ b/content/templates/foreldrepenger-innvilgelse/testdata/utbetaling/førstegangsbehandling_full_refusjon.json
@@ -50,23 +50,6 @@
   "perioder": [
     {
       "innvilget": true,
-      "årsak": "4095",
-      "periodeFom": "15. april 2021",
-      "periodeTom": "18. august 2021",
-      "periodeDagsats": 2209,
-      "antallTapteDager": 0,
-      "arbeidsforholdsliste": [
-        {
-          "arbeidsgiverNavn": "ARBEIDSGIVER AS",
-          "gradering": false,
-          "utbetalingsgrad": 100,
-          "prosentArbeid": 0,
-          "stillingsprosent": 100
-        }
-      ]
-    },
-    {
-      "innvilget": true,
       "årsak": "2010",
       "periodeFom": "19. august 2021",
       "periodeTom": "24. september 2021",

--- a/content/templates/foreldrepenger-innvilgelse/utbetaling_en.hbs
+++ b/content/templates/foreldrepenger-innvilgelse/utbetaling_en.hbs
@@ -23,6 +23,4 @@ We have extended the parental benefit period by {{foreldrepengeperiodenUtvidetUk
 {{#gt antallBarn 1}}We have extended the parental benefit period by {{foreldrepengeperiodenUtvidetUker}} weeks because you are adopting more than one child.{{/gt}}{{/if}}
 {{/gt}}
 
-{{#each perioder}}{{#eq årsak "4095"}}The parental benefit period starts three weeks before the estimated date of delivery. You have not claimed parental benefit from {{periodeFom}} up to and including {{periodeTom}}. You will therefore lose {{#gt antallTapteDager 1}}these days{{else}}this day{{/gt}}. If you want to take out {{#gt antallTapteDager 1}}these days{{else}}this day{{/gt}}, you must apply for this on nav.no.{{/eq}}{{/each}}
-
 {{#gt dagerTaptFørTermin 0}}{{#if fbEllerRvInnvilget gjelderFødsel}}Because you gave birth before the due date, you lose {{dagerTaptFørTermin}} {{#gt dagerTaptFørTermin 1}}days{{else}}day{{/gt}} of parental benefit.{{/if}}{{/gt}}

--- a/content/templates/foreldrepenger-innvilgelse/utbetaling_nb.hbs
+++ b/content/templates/foreldrepenger-innvilgelse/utbetaling_nb.hbs
@@ -22,6 +22,4 @@ Vi har forlenget foreldrepengeperioden med {{foreldrepengeperiodenUtvidetUker}} 
 {{else}}
 {{#gt antallBarn 1}}Vi har forlenget foreldrepengeperioden med {{foreldrepengeperiodenUtvidetUker}} uker fordi {{#eq aleneomsorgKode "JA"}}du{{else}}dere{{/eq}} adopterer flere barn.{{/gt}}{{/if}}{{/gt}}
 
-{{#each perioder}}{{#eq årsak "4095"}}Perioden med foreldrepenger starter tre uker før termin. Du har ikke tatt ut foreldrepenger fra og med {{periodeFom}} til og med {{periodeTom}}. Derfor mister du {{#gt antallTapteDager 1}}disse dagene{{else}}denne dagen{{/gt}}. Dersom du ønsker å ta ut {{#gt antallTapteDager 1}}disse dagene{{else}}denne dagen{{/gt}}, må du søke om det på nav.no.{{/eq}}{{/each}}
-
 {{#gt dagerTaptFørTermin 0}}{{#if fbEllerRvInnvilget gjelderFødsel}}Fordi du fødte før termin, mister du {{dagerTaptFørTermin}} {{#gt dagerTaptFørTermin 1}}dager{{else}}dag{{/gt}} med foreldrepenger.{{/if}}{{/gt}}

--- a/content/templates/foreldrepenger-innvilgelse/utbetaling_nn.hbs
+++ b/content/templates/foreldrepenger-innvilgelse/utbetaling_nn.hbs
@@ -22,6 +22,4 @@ Vi har forlengd foreldrepengeperioden med {{foreldrepengeperiodenUtvidetUker}} v
 {{else}}
 {{#gt antallBarn 1}}Vi har forlengd foreldrepengeperioden med {{foreldrepengeperiodenUtvidetUker}} veker fordi {{#eq aleneomsorgKode "JA"}}du{{else}}de{{/eq}} adopterer fleire barn.{{/gt}}{{/if}}{{/gt}}
 
-{{#each perioder}}{{#eq årsak "4095"}}Perioden med foreldrepengar startar tre veker før termin. Du har ikkje teke ut foreldrepengar frå og med {{periodeFom}} til og med {{periodeTom}}. Derfor mistar du {{#gt antallTapteDager 1}}desse dagane{{else}}denne dagen{{/gt}}. Dersom du ønskjer å ta ut {{#gt antallTapteDager 1}}desse dagane{{else}}denne dagen{{/gt}}, må du søkje om det på nav.no.{{/eq}}{{/each}}
-
 {{#gt dagerTaptFørTermin 0}}{{#if fbEllerRvInnvilget gjelderFødsel}}Fordi du fødde før termin, mistar du {{dagerTaptFørTermin}} {{#gt dagerTaptFørTermin 1}}dagar{{else}}dag{{/gt}} med foreldrepengar.{{/if}}{{/gt}}

--- a/src/test/resources/expected/foreldrepenger-innvilgelse/avslag/førstegangsbehandling_avslag_en.txt
+++ b/src/test/resources/expected/foreldrepenger-innvilgelse/avslag/førstegangsbehandling_avslag_en.txt
@@ -1,5 +1,6 @@
 <br/>
 ##### We have denied the following
+* The parental benefit period starts three weeks before the estimated date of delivery. You have not claimed parental benefit from 15. april 2021 up to and including 18. august 2021. You will therefore lose these days. If you want to take out these days, you must apply for this on [nav.no/foreldrepenger](https://nav.no/foreldrepenger).
 * You cannot postpone parental benefit from 19. august 2021 up to and including 24. september 2021 because you are receiving attendance allowance in this period.
   Periods before due date cannot be postponed because you gave birth before 33rd week of pregnancy.
 * You are not entitled to parental benefit from 27. september 2021 up to and including 25. november 2021.

--- a/src/test/resources/expected/foreldrepenger-innvilgelse/avslag/førstegangsbehandling_avslag_nb.txt
+++ b/src/test/resources/expected/foreldrepenger-innvilgelse/avslag/førstegangsbehandling_avslag_nb.txt
@@ -2,6 +2,8 @@
 
 ##### Dette har vi avslått
 
+* Perioden med foreldrepenger starter tre uker før termin. Du har ikke tatt ut foreldrepenger fra og med 15. april 2021 til og med 18. august 2021. Derfor mister du disse dagene. Dersom du ønsker å ta ut disse dagene, må du søke om det på [nav.no/foreldrepenger](https://nav.no/foreldrepenger).
+
 * Du kan ikke utsette foreldrepengene fra og med 19. august 2021 til og med 24. september 2021 fordi du får pleiepenger i denne perioden.
 
   Perioder før termindato kan ikke utsettes fordi du fødte før svangerskapsuke 33.

--- a/src/test/resources/expected/foreldrepenger-innvilgelse/avslag/førstegangsbehandling_avslag_nn.txt
+++ b/src/test/resources/expected/foreldrepenger-innvilgelse/avslag/førstegangsbehandling_avslag_nn.txt
@@ -1,6 +1,8 @@
 <br/>
 ##### Dette har vi avslått
 
+* Perioden med foreldrepengar startar tre veker før termin. Du har ikkje teke ut foreldrepengar frå og med 15. april 2021 til og med 18. august 2021. Derfor mistar du disse dagane. Dersom du ønskjer å ta ut disse dagane, må du søkje om det på [nav.no/foreldrepenger](https://nav.no/foreldrepenger).
+
 * Du kan ikkje utsetje foreldrepengane frå og med 19. august 2021 til og med 24. september 2021 fordi du får pleiepengar i denne perioden.
 
   Periodar før termindato kan ikkje utsetjast fordi du fødde før svangerskapsveke 33.

--- a/src/test/resources/expected/foreldrepenger-innvilgelse/utbetaling/utbetaling_full_refusjon_en.txt
+++ b/src/test/resources/expected/foreldrepenger-innvilgelse/utbetaling/utbetaling_full_refusjon_en.txt
@@ -4,4 +4,4 @@ The other parent is entitled to parental benefit. You will therefore not be gran
 You do not have lone care for the children and will therefore not be granted the whole parental benefit period.
 We have extended the parental benefit period by 1 day because you gave birth before the 33rd week of pregnancy.
 We have extended the parental benefit period by 3 weeks because you got more than one child.
-The parental benefit period starts three weeks before the estimated date of delivery. You have not claimed parental benefit from 15. april 2021 up to and including 18. august 2021. You will therefore lose this day. If you want to take out this day, you must apply for this on nav.no.
+

--- a/src/test/resources/expected/foreldrepenger-innvilgelse/utbetaling/utbetaling_full_refusjon_nb.txt
+++ b/src/test/resources/expected/foreldrepenger-innvilgelse/utbetaling/utbetaling_full_refusjon_nb.txt
@@ -10,4 +10,3 @@ Vi har forlenget foreldrepengeperioden med 1 dag fordi du fødte før svangerska
 
 Vi har forlenget foreldrepengeperioden med 3 uker fordi dere fikk flere barn.
 
-Perioden med foreldrepenger starter tre uker før termin. Du har ikke tatt ut foreldrepenger fra og med 15. april 2021 til og med 18. august 2021. Derfor mister du denne dagen. Dersom du ønsker å ta ut denne dagen, må du søke om det på nav.no.

--- a/src/test/resources/expected/foreldrepenger-innvilgelse/utbetaling/utbetaling_full_refusjon_nn.txt
+++ b/src/test/resources/expected/foreldrepenger-innvilgelse/utbetaling/utbetaling_full_refusjon_nn.txt
@@ -10,4 +10,3 @@ Vi har forlengd foreldrepengeperioden med 1 dag fordi du fødde før svangerskap
 
 Vi har forlengd foreldrepengeperioden med 3 veker fordi de fekk fleire barn.
 
-Perioden med foreldrepengar startar tre veker før termin. Du har ikkje teke ut foreldrepengar frå og med 15. april 2021 til og med 18. august 2021. Derfor mistar du denne dagen. Dersom du ønskjer å ta ut denne dagen, må du søkje om det på nav.no.


### PR DESCRIPTION
Flyttet tekst knyttet til årsak 4095(mor tar ikke alle ukene før fødsel) til avslagsmal og teksten skrives ut dersom morKanSøkeOmDagerFørFødsel er true (kan fortsatt søke for å få avslåtte dager innvilget)