### PR TITLE
FIX: Lagt til 4087 i FP avslag brevet. Rettet så 1024-testen for FP o…

### DIFF
--- a/content/templates/foreldrepenger-avslag/template_en.hbs
+++ b/content/templates/foreldrepenger-avslag/template_en.hbs
@@ -369,6 +369,13 @@
 {{>punkt}}You are not entitled to parental benefit from {{periodeFom}} up to and including {{periodeTom}}, because the earliest you can receive parental benefit is from the day you assume care of the {{#gt antallBarn 1}}children{{else}}child{{/gt}}.
 {{/eq}}
 
+
+{{#eq avslagsårsak "4087"}}
+{{>punkt}}You are not entitled to parental benefit from {{periodeFom}} up to and including {{periodeTom}} because you are not a member of the Norwegian National Insurance Scheme.
+
+  You do not have the right to reside in Norway during this period.
+{{/eq}}
+
 {{/each}}
 {{/if}}
 

--- a/content/templates/foreldrepenger-avslag/template_nb.hbs
+++ b/content/templates/foreldrepenger-avslag/template_nb.hbs
@@ -370,6 +370,13 @@
 {{>punkt}}Du har ikke rett til foreldrepenger fra og med {{periodeFom}} til og med {{periodeTom}} fordi du tidligst kan få foreldrepenger fra den dagen du overtar omsorgen for {{#gt antallBarn 1}}barna{{else}}barnet{{/gt}}.
 {{/eq}}
 
+
+{{#eq avslagsårsak "4087"}}
+{{>punkt}}Du har ikke rett til foreldrepenger fra og med {{periodeFom}} til og med {{periodeTom}} fordi du ikke er medlem i folketrygden.
+
+  Du har ikke oppholdstillatelse i Norge i denne perioden.
+{{/eq}}
+
 {{/each}}
 {{/if}}
 

--- a/content/templates/foreldrepenger-avslag/template_nn.hbs
+++ b/content/templates/foreldrepenger-avslag/template_nn.hbs
@@ -369,6 +369,13 @@
 {{>punkt}}Du har ikkje rett til foreldrepengar frå og med {{periodeFom}} til og med {{periodeTom}} fordi du tidlegast kan få foreldrepengar frå den dagen du overtek omsorga for {{#gt antallBarn 1}}barna{{else}}barnet{{/gt}}.
 {{/eq}}
 
+
+{{#eq avslagsårsak "4087"}}
+{{>punkt}}Du har ikkje rett til foreldrepengar frå og med {{periodeFom}} til og med {{periodeTom}} fordi du ikkje er medlem i folketrygda.
+
+  Du har ikkje opphaldsløyve i Noreg i denne perioden.
+{{/eq}}
+
 {{/each}}
 {{/if}}
 

--- a/content/templates/foreldrepenger-avslag/testdata/test_mange.json
+++ b/content/templates/foreldrepenger-avslag/testdata/test_mange.json
@@ -507,44 +507,50 @@
     },
     {
       "avslagsårsak": "4115",
-      "periodeFom": "25. juli 2021",
-      "periodeTom": "26. juli 2021",
+      "periodeFom": "11. september 2021",
+      "periodeTom": "12. september 2021",
       "antallTapteDager": 1
     },
     {
       "avslagsårsak": "4116",
-      "periodeFom": "27. juli 2021",
-      "periodeTom": "28. juli 2021",
+      "periodeFom": "13. september 2021",
+      "periodeTom": "14. september 2021",
       "antallTapteDager": 1
     },
     {
       "avslagsårsak": "4117",
-      "periodeFom": "29. juli 2021",
-      "periodeTom": "30. juli 2021",
+      "periodeFom": "15. september 2021",
+      "periodeTom": "16. september 2021",
       "antallTapteDager": 1
     },
     {
       "avslagsårsak": "4110",
-      "periodeFom": "1. august 2021",
-      "periodeTom": "2. august 2021",
+      "periodeFom": "17. september 2021",
+      "periodeTom": "18. september 2021",
       "antallTapteDager": 1
     },
     {
       "avslagsårsak": "4112",
-      "periodeFom": "3. august 2021",
-      "periodeTom": "4. august 2021",
+      "periodeFom": "19. september 2021",
+      "periodeTom": "20. september 2021",
       "antallTapteDager": 1
     },
     {
       "avslagsårsak": "4111",
-      "periodeFom": "5. august 2021",
-      "periodeTom": "6. august 2021",
+      "periodeFom": "21. september 2021",
+      "periodeTom": "22. september 2021",
       "antallTapteDager": 1
     },
     {
       "avslagsårsak": "4102",
-      "periodeFom": "15. juni 2021",
-      "periodeTom": "16. juni 2021",
+      "periodeFom": "23. september 2021",
+      "periodeTom": "24. september 2021",
+      "antallTapteDager": 1
+    },
+    {
+      "avslagsårsak": "4087",
+      "periodeFom": "25. september 2021",
+      "periodeTom": "26. september 2021",
       "antallTapteDager": 1
     }
   ]

--- a/src/test/java/no/nav/foreldrepenger/dokgen/test/templates/ForeldrepengerOpphørTest.java
+++ b/src/test/java/no/nav/foreldrepenger/dokgen/test/templates/ForeldrepengerOpphørTest.java
@@ -4,7 +4,6 @@ import static no.nav.foreldrepenger.dokgen.test.support.TemplateTestService.comp
 import static no.nav.foreldrepenger.dokgen.test.support.TemplateTestService.getExpected;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -108,14 +107,13 @@ public class ForeldrepengerOpphørTest {
         assertThat(content).contains(String.format("Vi har fått opplyst at barna dine døde %s. Den siste dagen din med foreldrepenger er derfor %s", BARN_DØDSDATO, STØNADSDATO_TOM));
     }
 
-    @Disabled //FIXME Michal - feiler lokalt hos meg
     @Test
     public void test_kode_søker_1024_og_opphørdato() throws Exception {
         var testData = opprettTestData();
         opprettÅrsaker(testData, "1024");
 
         var content = compileContent(BREVMAL, Språk.BOKMÅL, testData);
-        assertThat(content).contains("Du hadde ikke rett til foreldrepenger fordi du ikke var medlem i folketrygden på det tidspunktet barna dine ble født.\nVi har ikke opplysninger om at du jobbet eller hadde familie som forsørget deg i Norge. Det var derfor ikke dokumentert at du hadde rett til opphold etter EØS-avtalen.");
+        assertThat(content).containsIgnoringWhitespaces("Du hadde ikke rett til foreldrepenger fordi du ikke var medlem i folketrygden på det tidspunktet barna dine ble født.\nVi har ikke opplysninger om at du jobbet eller hadde familie som forsørget deg i Norge. Det var derfor ikke dokumentert at du hadde rett til opphold etter EØS-avtalen.");
     }
 
     private void opprettÅrsaker(final ObjectNode testData, String... årsaker) {

--- a/src/test/resources/expected/foreldrepenger-avslag/foreldrepenger-avslag_mange_en.txt
+++ b/src/test/resources/expected/foreldrepenger-avslag/foreldrepenger-avslag_mange_en.txt
@@ -217,16 +217,16 @@ National identity number: 300220 12345
 * You cannot postpone parental benefit from 7. september 2021 up to and including 8. september 2021, because you have applied too late. To be entitled to postpone parental benefit, you must apply before the start of the holiday.
 
 * You are not entitled to parental benefit from 9. september 2021 up to and including 10. september 2021, because the earliest you can receive parental benefit is from the day you assume care of the child.
-* You have applied to postpone parental benefit from 25. juli 2021 up to and including 26. juli 2021, but you have not sent us the documentation we asked for. We therefore do not have enough information to assess whether you are entitled to postpone parental benefit.
-* You have applied to postpone parental benefit from 27. juli 2021 up to and including 28. juli 2021, but you have not sent us the documentation we asked for. We therefore do not have enough information to assess whether you are entitled to postpone parental benefit.
-* You have applied to postpone parental benefit from 29. juli 2021 up to and including 30. juli 2021, but you have not sent us the documentation we asked for. We therefore do not have enough information to assess whether you are entitled to postpone parental benefit.
-* You cannot postpone parental benefit from 1. august 2021 up to and including 2. august 2021.
-
+* You have applied to postpone parental benefit from 11. september 2021 up to and including 12. september 2021, but you have not sent us the documentation we asked for. We therefore do not have enough information to assess whether you are entitled to postpone parental benefit.
+* You have applied to postpone parental benefit from 13. september 2021 up to and including 14. september 2021, but you have not sent us the documentation we asked for. We therefore do not have enough information to assess whether you are entitled to postpone parental benefit.
+* You have applied to postpone parental benefit from 15. september 2021 up to and including 16. september 2021, but you have not sent us the documentation we asked for. We therefore do not have enough information to assess whether you are entitled to postpone parental benefit.
+* You cannot postpone parental benefit from 17. september 2021 up to and including 18. september 2021.
   In order to postpone parental benefit on grounds of illness, you must be fully dependent on help to be able to take care of the child due to your own illness. The medical certificate from your doctor does not indicate that this is the case.
-
-* You cannot postpone parental benefit from 3. august 2021 up to and including 4. august 2021 because your child is not admitted to a health care institution.
-* You cannot postpone parental benefit from 5. august 2021 up to and including 6. august 2021 because you have not been admitted to a health care institution.
-* You have not applied for parental benefit from 15. juni 2021 up to and including 16. juni 2021, nor have you informed us that the other parent is working, studying or is in any other approved activity. You have therefore lost 1 day.
+* You cannot postpone parental benefit from 19. september 2021 up to and including 20. september 2021 because your child is not admitted to a health care institution.
+* You cannot postpone parental benefit from 21. september 2021 up to and including 22. september 2021 because you have not been admitted to a health care institution.
+* You have not applied for parental benefit from 23. september 2021 up to and including 24. september 2021, nor have you informed us that the other parent is working, studying or is in any other approved activity. You have therefore lost 1 day.
+* You are not entitled to parental benefit from 25. september 2021 up to and including 26. september 2021 because you are not a member of the Norwegian National Insurance Scheme.
+  You do not have the right to reside in Norway during this period.
 
 The decision has been made in accordance with the National Insurance Act Section § forvaltningsloven § 35.
 

--- a/src/test/resources/expected/foreldrepenger-avslag/foreldrepenger-avslag_mange_nb.txt
+++ b/src/test/resources/expected/foreldrepenger-avslag/foreldrepenger-avslag_mange_nb.txt
@@ -219,15 +219,16 @@ Fødselsnummer: 300220 12345
   For å ha rett til å utsette foreldrepengene må du søke før ferien starter.
 
 * Du har ikke rett til foreldrepenger fra og med 9. september 2021 til og med 10. september 2021 fordi du tidligst kan få foreldrepenger fra den dagen du overtar omsorgen for barnet.
-* Du har søkt om å utsette foreldrepengene fra og med 25. juli 2021 til og med 26. juli 2021, men du har ikke sendt oss dokumentasjonen vi har bedt om. Derfor har vi ikke nok opplysninger til å vurdere om du har rett til å utsette.
-* Du har søkt om å utsette foreldrepengene fra og med 27. juli 2021 til og med 28. juli 2021, men du har ikke sendt oss dokumentasjonen vi har bedt om. Derfor har vi ikke nok opplysninger til å vurdere om du har rett til å utsette.
-* Du har søkt om å utsette foreldrepengene fra og med 29. juli 2021 til og med 30. juli 2021, men du har ikke sendt oss dokumentasjonen vi har bedt om. Derfor har vi ikke nok opplysninger til å vurdere om du har rett til å utsette.
-* Du kan ikke utsette foreldrepengene fra og med 1. august 2021 til og med 2. august 2021.
-
+* Du har søkt om å utsette foreldrepengene fra og med 11. september 2021 til og med 12. september 2021, men du har ikke sendt oss dokumentasjonen vi har bedt om. Derfor har vi ikke nok opplysninger til å vurdere om du har rett til å utsette.
+* Du har søkt om å utsette foreldrepengene fra og med 13. september 2021 til og med 14. september 2021, men du har ikke sendt oss dokumentasjonen vi har bedt om. Derfor har vi ikke nok opplysninger til å vurdere om du har rett til å utsette.
+* Du har søkt om å utsette foreldrepengene fra og med 15. september 2021 til og med 16. september 2021, men du har ikke sendt oss dokumentasjonen vi har bedt om. Derfor har vi ikke nok opplysninger til å vurdere om du har rett til å utsette.
+* Du kan ikke utsette foreldrepengene fra og med 17. september 2021 til og med 18. september 2021.
   For å kunne utsette foreldrepengene på grunn av sykdom, må du være er helt avhengig av hjelp til å ta deg av barnet. Legeerklæringen viser ikke dette.
-* Du kan ikke utsette foreldrepengene fra og med 3. august 2021 til og med 4. august 2021 fordi barnet ditt ikke er innlagt i helseinstitusjon.
-* Du kan ikke utsette foreldrepengene fra og med 5. august 2021 til og med 6. august 2021 fordi du ikke er innlagt i helseinstitusjon.
-* Du har ikke søkt om foreldrepenger fra og med 15. juni 2021 til og med 16. juni 2021. Du har heller ikke oppgitt at mor jobber, studerer eller er i annen aktivitet i denne perioden. Derfor har du mistet 1 dag.
+* Du kan ikke utsette foreldrepengene fra og med 19. september 2021 til og med 20. september 2021 fordi barnet ditt ikke er innlagt i helseinstitusjon.
+* Du kan ikke utsette foreldrepengene fra og med 21. september 2021 til og med 22. september 2021 fordi du ikke er innlagt i helseinstitusjon.
+* Du har ikke søkt om foreldrepenger fra og med 23. september 2021 til og med 24. september 2021. Du har heller ikke oppgitt at mor jobber, studerer eller er i annen aktivitet i denne perioden. Derfor har du mistet 1 dag.
+* Du har ikke rett til foreldrepenger fra og med 25. september 2021 til og med 26. september 2021 fordi du ikke er medlem i folketrygden.
+  Du har ikke oppholdstillatelse i Norge i denne perioden.
 
 Vedtaket er gjort etter folketrygdloven § forvaltningsloven § 35.
 

--- a/src/test/resources/expected/foreldrepenger-avslag/foreldrepenger-avslag_mange_nn.txt
+++ b/src/test/resources/expected/foreldrepenger-avslag/foreldrepenger-avslag_mange_nn.txt
@@ -219,15 +219,16 @@ Fødselsnummer: 300220 12345
   For å ha rett til å utsetje foreldrepengane må du søkje før ferien startar.
 
 * Du har ikkje rett til foreldrepengar frå og med 9. september 2021 til og med 10. september 2021 fordi du tidlegast kan få foreldrepengar frå den dagen du overtek omsorga for barnet.
-* Du har søkt om å utsetje foreldrepengane frå og med 25. juli 2021 til og med 26. juli 2021, men du har ikkje sendt oss dokumentasjonen vi har bede om. Derfor har vi ikkje nok opplysningar til å vurdere om du har rett til å utsetje.
-* Du har søkt om å utsetje foreldrepengane frå og med 27. juli 2021 til og med 28. juli 2021, men du har ikkje sendt oss dokumentasjonen vi har bede om. Derfor har vi ikkje nok opplysningar til å vurdere om du har rett til å utsetje.
-* Du har søkt om å utsetje foreldrepengane frå og med 29. juli 2021 til og med 30. juli 2021, men du har ikkje sendt oss dokumentasjonen vi har bede om. Derfor har vi ikkje nok opplysningar til å vurdere om du har rett til å utsetje.
-* Du kan ikkje utsetje foreldrepengane frå og med 1. august 2021 til og med 2. august 2021.
-
+* Du har søkt om å utsetje foreldrepengane frå og med 11. september 2021 til og med 12. september 2021, men du har ikkje sendt oss dokumentasjonen vi har bede om. Derfor har vi ikkje nok opplysningar til å vurdere om du har rett til å utsetje.
+* Du har søkt om å utsetje foreldrepengane frå og med 13. september 2021 til og med 14. september 2021, men du har ikkje sendt oss dokumentasjonen vi har bede om. Derfor har vi ikkje nok opplysningar til å vurdere om du har rett til å utsetje.
+* Du har søkt om å utsetje foreldrepengane frå og med 15. september 2021 til og med 16. september 2021, men du har ikkje sendt oss dokumentasjonen vi har bede om. Derfor har vi ikkje nok opplysningar til å vurdere om du har rett til å utsetje.
+* Du kan ikkje utsetje foreldrepengane frå og med 17. september 2021 til og med 18. september 2021.
   For å utsetje foreldrepengane på grunn av sjukdom må du vere heilt avhengig av hjelp til å ta deg av barnet. Legeerklæringa di viser ikkje dette.
-* Du kan ikkje utsetje foreldrepengane frå og med 3. august 2021 til og med 4. august 2021 fordi barnet ditt ikkje er innlagd i helseinstitusjon.
-* Du kan ikkje utsetje foreldrepengane frå og med 5. august 2021 til og med 6. august 2021 fordi du ikkje er innlagd i helseinstitusjon.
-* Du har ikkje søkt om foreldrepengar frå og med 15. juni 2021 til og med 16. juni 2021. Du har heller ikkje oppgitt at mor jobbar, studerer eller er i annan aktivitet i denne perioden. Derfor har du mista 1 dag.
+* Du kan ikkje utsetje foreldrepengane frå og med 19. september 2021 til og med 20. september 2021 fordi barnet ditt ikkje er innlagd i helseinstitusjon.
+* Du kan ikkje utsetje foreldrepengane frå og med 21. september 2021 til og med 22. september 2021 fordi du ikkje er innlagd i helseinstitusjon.
+* Du har ikkje søkt om foreldrepengar frå og med 23. september 2021 til og med 24. september 2021. Du har heller ikkje oppgitt at mor jobbar, studerer eller er i annan aktivitet i denne perioden. Derfor har du mista 1 dag.
+* Du har ikkje rett til foreldrepengar frå og med 25. september 2021 til og med 26. september 2021 fordi du ikkje er medlem i folketrygda.
+  Du har ikkje opphaldsløyve i Noreg i denne perioden.
 
 Vedtaket er gjort etter folketrygdlova § forvaltningsloven § 35.
 


### PR DESCRIPTION
…pphør også fungerer på Windows ved at whitespaces (linjeskift?) ignoreres.

@mrsladek: Jeg fikk testen din med linjeskift i FP opphør til å fungere på Windows ved å ignorere whitespaces - antar det skyldtes forskjellig koding av linjeskiftet.