### PR TITLE
Retter at overskrift ved svangerskapspenger opphør startet med liten …

### DIFF
--- a/content/templates/svangerskapspenger-opphor/template_en.hbs
+++ b/content/templates/svangerskapspenger-opphor/template_en.hbs
@@ -1,7 +1,7 @@
 {{> header_en }}
 
 {{#eq erSøkerDød true}}
-# pregnancy benefit for {{capitalize felles.søkerNavn fully=true}} is stopped
+# Pregnancy benefit for {{capitalize felles.søkerNavn fully=true}} is stopped
 {{> brukerdetaljer_en }}
 {{#eq opphørtPeriode.årsak "8304" }}
 We have been notified that {{felles.søkerNavn}}, who received pregnancy benefit from and including {{opphørtPeriode.stønadsperiodeFom}}, is dead.

--- a/src/test/resources/expected/svangerskapspenger-opphor/bruker_er_dod_en.txt
+++ b/src/test/resources/expected/svangerskapspenger-opphor/bruker_er_dod_en.txt
@@ -4,7 +4,7 @@ Date: 4. mai 2021
 <br>
 <br>
 <br>
-# pregnancy benefit for Dolly Duck is stopped
+# Pregnancy benefit for Dolly Duck is stopped
 <p style="color:gray">
 Nav's case number: 123456789
 <br/>


### PR DESCRIPTION
…bokstav på engelsk mal; Pregnancy benefit for <Bruker> is stopped