### PR TITLE
Forhåndsvisning: Flytter utkast oppe til høyre

### DIFF
--- a/content/formats/pdf/style.css
+++ b/content/formats/pdf/style.css
@@ -95,11 +95,9 @@ table {
 }
 
 .draft_text {
-    transform: rotate(45deg);
-    transform-origin: right top;
     position: absolute;
-    top: 600px;
+    top: 10px;
+    right: 10px;
     color: #dcdcdc;
-    font-size: 200px;
-    z-index: -1;
+    font-size: 50px;
 }


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/dc2d8d5b-ead4-45b3-94cf-2e605431a442)


Bakgrunn er at saksbehandler har vanske med å kopiere teksten i dagens overstyring.