### PR TITLE
chore: Juster cpu og minne etter anbefaling / behov

### DIFF
--- a/.deploy/dev-gcp-teamforeldrepenger.json
+++ b/.deploy/dev-gcp-teamforeldrepenger.json
@@ -3,11 +3,11 @@
   "minReplicas": "1",
   "maxReplicas": "2",
   "limits": {
-    "mem": "576Mi"
+    "mem": "800Mi"
   },
   "requests": {
-    "cpu": "71m",
-    "mem": "416Mi"
+    "cpu": "50m",
+    "mem": "640Mi"
   },
   "ingresses": [
     "https://fpdokgen.intern.dev.nav.no"

--- a/.deploy/naiserator.yaml
+++ b/.deploy/naiserator.yaml
@@ -36,6 +36,7 @@ spec:
     scalingStrategy:
       cpu:
         thresholdPercentage: 80
+      scaleUpStabilizationWindowSeconds: 60
   resources:
     limits:
       memory: "{{limits.mem}}"

--- a/.deploy/prod-gcp-teamforeldrepenger.json
+++ b/.deploy/prod-gcp-teamforeldrepenger.json
@@ -3,11 +3,11 @@
   "minReplicas": "2",
   "maxReplicas": "3",
   "limits": {
-    "mem": "640Mi"
+    "mem": "1000Mi"
   },
   "requests": {
-    "cpu": "212m",
-    "mem": "512Mi"
+    "cpu": "100m",
+    "mem": "800Mi"
   },
   "ingresses": [
     "https://fpdokgen.intern.nav.no"


### PR DESCRIPTION
Fjerner cpu-limit, og justerer cpu- og minneforespørsler til anbefalte verdier.

- Fjerner `limits.cpu` fra naiserator.yaml og JSON-filer
- Dev: cpu request=50m, mem request=640Mi, mem limit=800Mi
- Prod: cpu request=100m, mem request=800Mi, mem limit=1000Mi