### PR TITLE
TFP-5726: Endre prematur avslag-tekst til kjønnsnøytral formulering

### DIFF
--- a/src/main/resources/content/templates/foreldrepenger-innvilgelse/avslag_en.hbs
+++ b/src/main/resources/content/templates/foreldrepenger-innvilgelse/avslag_en.hbs
@@ -17,7 +17,7 @@
 {{#case "4077"}}
 {{>punkt}}You cannot postpone parental benefit from {{periodeFom}} up to and including {{periodeTom}} because you are receiving attendance allowance in this period.
 
-  Periods before due date cannot be postponed because you gave birth before 33rd week of pregnancy.
+  Periods before due date cannot be postponed when the {{#gt antallBarn 1}}children are{{else}}child is{{/gt}} born before the 33rd week of pregnancy.
 {{/case}}
 {{#case "4020"}}{{#gt antallTapteDager 0}}{{>punkt}}You are not entitled to parental benefit from {{periodeFom}} up to and including {{periodeTom}}.
 

--- a/src/main/resources/content/templates/foreldrepenger-innvilgelse/avslag_nb.hbs
+++ b/src/main/resources/content/templates/foreldrepenger-innvilgelse/avslag_nb.hbs
@@ -17,7 +17,7 @@
 {{#case "4077"}}
 {{>punkt}}Du kan ikke utsette foreldrepengene fra og med {{periodeFom}} til og med {{periodeTom}} fordi du får pleiepenger i denne perioden.
 
-  Perioder før termindato kan ikke utsettes fordi du fødte før svangerskapsuke 33.
+  Perioder før termindato kan ikke utsettes når {{#gt antallBarn 1}}barna{{else}}barnet{{/gt}} er født før svangerskapsuke 33.
 {{/case}}
 {{#case "4020"}}{{#gt antallTapteDager 0}}{{>punkt}}Du har ikke rett til foreldrepenger fra og med {{periodeFom}} til og med {{periodeTom}}.
 

--- a/src/main/resources/content/templates/foreldrepenger-innvilgelse/avslag_nn.hbs
+++ b/src/main/resources/content/templates/foreldrepenger-innvilgelse/avslag_nn.hbs
@@ -17,7 +17,7 @@
 {{#case "4077"}}
 {{>punkt}}Du kan ikkje utsetje foreldrepengane frå og med {{periodeFom}} til og med {{periodeTom}} fordi du får pleiepengar i denne perioden.
 
-  Periodar før termindato kan ikkje utsetjast fordi du fødde før svangerskapsveke 33.
+  Periodar før termindato kan ikkje utsetjast når {{#gt antallBarn 1}}barna{{else}}barnet{{/gt}} er fødd før svangerskapsveke 33.
 {{/case}}
 {{#case "4020"}}{{#gt antallTapteDager 0}}{{>punkt}}Du har ikkje rett til foreldrepengar frå og med {{periodeFom}} til og med {{periodeTom}}.
 

--- a/src/test/java/content/support/TemplateTestUtil.java
+++ b/src/test/java/content/support/TemplateTestUtil.java
@@ -18,6 +18,11 @@ public final class TemplateTestUtil {
         return getJsonFromString(mergeFieldsJsonString);
     }
 
+    public static String compileContent(BrevMal brevmal, String undermal, Språk språk, Map<String, Object> testData) {
+        var templateContent = readContent(TestContentUtil.hentPathForMal(brevmal, undermal, språk));
+        return produceContent(testData, templateContent);
+    }
+
     public static String compileContent(BrevMal brevmal, String undermal, Språk språk, String testDataFilename) {
         var templateContent = readContent(TestContentUtil.hentPathForMal(brevmal, undermal, språk));
         var mergeFieldsJsonString = readContent(TestContentUtil.getTestDataPath(brevmal, undermal, testDataFilename));

--- a/src/test/java/content/templates/innvilgelsefp/ForeldrepengerInnvilgelseAvslagTest.java
+++ b/src/test/java/content/templates/innvilgelsefp/ForeldrepengerInnvilgelseAvslagTest.java
@@ -2,6 +2,7 @@ package content.templates.innvilgelsefp;
 
 import static content.support.TemplateTestUtil.compileContent;
 import static content.support.TemplateTestUtil.getExpected;
+import static content.support.TemplateTestUtil.getTestDataJson;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
@@ -32,5 +33,18 @@ class ForeldrepengerInnvilgelseAvslagTest {
         var content = compileContent(BREVMAL, UNDERMAL, Språk.ENGELSK, "førstegangsbehandling_avslag");
         var expected = getExpected(BREVMAL, UNDERMAL, "førstegangsbehandling_avslag_en.txt");
         assertThat(content).isEqualToIgnoringNewLines(expected);
+    }
+
+    @Test
+    void prematur_avslag_4077_flerbarns_bruker_flertallsform() {
+        var testDataJson = getTestDataJson(BREVMAL, UNDERMAL, "førstegangsbehandling_avslag");
+        testDataJson.put("antallBarn", 2);
+        var nb = compileContent(BREVMAL, UNDERMAL, Språk.BOKMÅL, testDataJson);
+        var nn = compileContent(BREVMAL, UNDERMAL, Språk.NYNORSK, testDataJson);
+        var en = compileContent(BREVMAL, UNDERMAL, Språk.ENGELSK, testDataJson);
+
+        assertThat(nb).contains("kan ikke utsettes når barna er født før svangerskapsuke 33");
+        assertThat(nn).contains("kan ikkje utsetjast når barna er fødd før svangerskapsveke 33");
+        assertThat(en).contains("cannot be postponed when the children are born before the 33rd week of pregnancy");
     }
 }

--- a/src/test/resources/testdata/foreldrepenger-innvilgelse/expected/avslag/førstegangsbehandling_avslag_en.txt
+++ b/src/test/resources/testdata/foreldrepenger-innvilgelse/expected/avslag/førstegangsbehandling_avslag_en.txt
@@ -1,7 +1,7 @@
 ## We have denied the following
 * The parental benefit period starts three weeks before the estimated date of delivery. You have not claimed parental benefit from 15. april 2021 up to and including 18. august 2021. You will therefore lose these days. If you want to take out these days, you must apply for this on [nav.no/foreldrepenger](https://nav.no/foreldrepenger).
 * You cannot postpone parental benefit from 19. august 2021 up to and including 24. september 2021 because you are receiving attendance allowance in this period.
-  Periods before due date cannot be postponed because you gave birth before 33rd week of pregnancy.
+  Periods before due date cannot be postponed when the child is born before the 33rd week of pregnancy.
 * You are not entitled to parental benefit from 27. september 2021 up to and including 25. november 2021.
   You must apply no later than three months after the period of parental benefit started. You applied on 15. januar 2022. You will therefore have 3 fewer days with parental benefit.
 * No application has been submitted for parental benefit or postponement from 26. november 2021 up to and including 17. januar 2022. Therefore, 2 days have been lost.

--- a/src/test/resources/testdata/foreldrepenger-innvilgelse/expected/avslag/førstegangsbehandling_avslag_nb.txt
+++ b/src/test/resources/testdata/foreldrepenger-innvilgelse/expected/avslag/førstegangsbehandling_avslag_nb.txt
@@ -1,7 +1,7 @@
 ## Dette har vi avslått
 * Perioden med foreldrepenger starter tre uker før termin. Du har ikke tatt ut foreldrepenger fra og med 15. april 2021 til og med 18. august 2021. Derfor mister du disse dagene. Dersom du ønsker å ta ut disse dagene, må du søke om det på [nav.no/foreldrepenger](https://nav.no/foreldrepenger).
 * Du kan ikke utsette foreldrepengene fra og med 19. august 2021 til og med 24. september 2021 fordi du får pleiepenger i denne perioden.
-  Perioder før termindato kan ikke utsettes fordi du fødte før svangerskapsuke 33.
+  Perioder før termindato kan ikke utsettes når barnet er født før svangerskapsuke 33.
 * Du har ikke rett til foreldrepenger fra og med 27. september 2021 til og med 25. november 2021.
   Du må søke senest tre måneder etter at perioden med foreldrepenger startet. Du søkte 15. januar 2022. Derfor får du 3 færre dager med foreldrepenger.
 * Det er ikke søkt om foreldrepenger eller utsettelse fra og med 26. november 2021 til og med 17. januar 2022. Derfor er 2 dager tapt.

--- a/src/test/resources/testdata/foreldrepenger-innvilgelse/expected/avslag/førstegangsbehandling_avslag_nn.txt
+++ b/src/test/resources/testdata/foreldrepenger-innvilgelse/expected/avslag/førstegangsbehandling_avslag_nn.txt
@@ -1,7 +1,7 @@
 ## Dette har vi avslått
 * Perioden med foreldrepengar startar tre veker før termin. Du har ikkje teke ut foreldrepengar frå og med 15. april 2021 til og med 18. august 2021. Derfor mistar du disse dagane. Dersom du ønskjer å ta ut disse dagane, må du søkje om det på [nav.no/foreldrepenger](https://nav.no/foreldrepenger).
 * Du kan ikkje utsetje foreldrepengane frå og med 19. august 2021 til og med 24. september 2021 fordi du får pleiepengar i denne perioden.
-  Periodar før termindato kan ikkje utsetjast fordi du fødde før svangerskapsveke 33.
+  Periodar før termindato kan ikkje utsetjast når barnet er fødd før svangerskapsveke 33.
 * Du har ikkje rett til foreldrepengar frå og med 27. september 2021 til og med 25. november 2021.
   Du må søkje seinast tre månader etter at perioden med foreldrepengar starta. Du søkte 15. januar 2022. Derfor får du 3 færre dagar med foreldrepengar.
 * Det er ikkje søkt om foreldrepengar eller utsetjing frå og med 26. november 2021 til og med 17. januar 2022. Derfor er 2 dagar tapte.


### PR DESCRIPTION
Prøver meg på tekstendringer

---

Endrer teksten i avslag 4077 (pleiepenger + prematur fødsel) fra 'fordi du fødte før svangerskapsuke 33' til
'når barnet/barna er født før svangerskapsuke 33' i alle tre språk (nb, nn, en). Bruker Handlebars-conditional for entall/flertall.

Legger til test for flertallsform (antallBarn > 1).