### PR TITLE
Chore: støtte handlebars 4.5.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
         <openhtmltopdf.version>1.1.37</openhtmltopdf.version>
         <commonmark.version>0.28.0</commonmark.version>
 
-        <handlebar.version>4.5.1</handlebar.version>
+        <handlebar.version>4.5.2</handlebar.version>
         <nv-i18n.version>1.29</nv-i18n.version>
     </properties>
 

--- a/src/main/java/no/nav/foreldrepenger/fpdokgen/tjenester/dokumentgenerator/handlebars/HandlebarsCustomHelpers.java
+++ b/src/main/java/no/nav/foreldrepenger/fpdokgen/tjenester/dokumentgenerator/handlebars/HandlebarsCustomHelpers.java
@@ -10,19 +10,26 @@ import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 
 import com.github.jknack.handlebars.Context;
 import com.github.jknack.handlebars.Helper;
 import com.github.jknack.handlebars.Options;
 import com.neovisionaries.i18n.CountryCode;
 
+import tools.jackson.databind.JsonNode;
+
 /**
  * Custom Handlebars helpers for document generation.
  */
 final class HandlebarsCustomHelpers {
+
+    private static final String CONDITION_VARIABLE = "__condition_variable";
+    private static final String CONDITION_FULFILLED = "__condition_fulfilled";
 
     private HandlebarsCustomHelpers() {
         // Utility class
@@ -45,16 +52,13 @@ final class HandlebarsCustomHelpers {
 
         @Override
         public Object apply(Object variable, Options options) throws IOException {
-            List<String> variabelNavn = new ArrayList<>();
-            List<Object> variabelVerdier = new ArrayList<>();
-            variabelNavn.add("__condition_fulfilled");
-            variabelVerdier.add(0);
-            variabelNavn.add("__condition_variable");
-            variabelVerdier.add(options.hash.isEmpty() ? variable : options.hash);
-            var ctx = Context.newBlockParamContext(options.context, variabelNavn, variabelVerdier);
+            var switchState = new HashMap<String, Object>();
+            switchState.put(CONDITION_FULFILLED, 0);
+            switchState.put(CONDITION_VARIABLE, options.hash.isEmpty() ? variable : options.hash);
+            var ctx = Context.newBuilder(options.context, switchState).build();
             String resultat = options.fn.apply(ctx);
 
-            var antall = (Integer) ctx.get("__condition_fulfilled");
+            var antall = (Integer) switchState.get(CONDITION_FULFILLED);
             if (Integer.valueOf(1).equals(antall)) {
                 return resultat;
             }
@@ -66,74 +70,55 @@ final class HandlebarsCustomHelpers {
      * @see SwitchHelper
      */
     static class CaseHelper implements Helper<Object> {
-        private static final String CONDITION_VARIABLE = "__condition_variable";
-        private static final String CONDITION_FULFILLED = "__condition_fulfilled";
-
         @Override
         @SuppressWarnings("unchecked")
         public Object apply(Object caseKonstant, Options options) throws IOException {
             var konstant = options.hash.isEmpty() ? caseKonstant : options.hash;
-            var model = (Map<String, Object>) options.context.model();
+            if (!(options.context.model() instanceof Map<?, ?> rawModel)) {
+                return options.inverse();
+            }
+            var model = (Map<String, Object>) rawModel;
             var conditionVariable = model.get(CONDITION_VARIABLE);
 
-            if (caseKonstant instanceof Iterable<?> iterable) {
-                var list = (List<?>) iterable;
-                if (list.contains(conditionVariable)) {
-                    incrementConditionFulfilledCounter(model);
-                    return options.fn();
-                }
-            } else if (konstant.equals(conditionVariable)) {
+            if (matches(konstant, conditionVariable)) {
                 incrementConditionFulfilledCounter(model);
                 return options.fn();
             }
             return options.inverse();
         }
 
-        private void incrementConditionFulfilledCounter(Map<String, Object> model) {
-            var antall = (Integer) model.get(CONDITION_FULFILLED);
-            model.put(CONDITION_FULFILLED, antall + 1);
-        }
-    }
-
-    /**
-     * Allows to create a table with a set number of columns from only td cells.
-     * Useful if you have to render table cells but you don't know how many cells you will have.
-     * <p>
-     * Example:
-     * {{#table [columns=2] [class=""]]}}
-     * <td>This is one cell</td>
-     * <td>This is another cell</td>
-     * <td>This is a third cell</td>
-     * {{/table}}
-     * <p>
-     * will render a table with two tr rows with two cells in each
-     */
-    static class TableHelper implements Helper<Object> {
-
-        @Override
-        public Object apply(Object context, Options options) throws IOException {
-            int columnCount = options.hash("columns", 2);
-            var tableContents = options.fn(context).toString();
-            var cells = Arrays.stream(tableContents.trim().split("</td>")).filter(s -> !s.isEmpty()).map(s -> s + "</td>").toList();
-
-            var wrappedInRows = new StringBuilder("<tr>");
-            for (int index = 0; index < cells.size(); index++) {
-                if (index > 0 && index % columnCount == 0) {
-                    wrappedInRows.append("</tr><tr>");
+        private static boolean matches(Object konstant, Object conditionVariable) {
+            if (konstant instanceof Iterable<?> iterable) {
+                for (var candidate : iterable) {
+                    if (equalsValue(candidate, conditionVariable)) {
+                        return true;
+                    }
                 }
-                wrappedInRows.append(cells.get(index));
+                return false;
             }
+            return equalsValue(konstant, conditionVariable);
+        }
 
-            if (cells.size() % columnCount > 0) {
-                int missingCellsInLastRow = columnCount - (cells.size() % columnCount);
-                wrappedInRows.append("<td></td>".repeat(missingCellsInLastRow));
+        private static boolean equalsValue(Object left, Object right) {
+            if (Objects.equals(left, right)) {
+                return true;
             }
+            return Objects.equals(normalize(left), normalize(right));
+        }
 
-            wrappedInRows.append("</tr>");
+        private static Object normalize(Object value) {
+            if (value instanceof JsonNode jsonNode) {
+                return jsonNode.isValueNode() ? jsonNode.asString() : jsonNode.toString();
+            }
+            if (value instanceof CharSequence charSequence) {
+                return charSequence.toString();
+            }
+            return value;
+        }
 
-            String classParam = options.hash("class", "");
-            var classString = classParam.isEmpty() ? "" : "class=" + classParam;
-            return "<table %s>%s</table>".formatted(classString, wrappedInRows);
+        private void incrementConditionFulfilledCounter(Map<String, Object> model) {
+            var antall = (Integer) model.getOrDefault(CONDITION_FULFILLED, 0);
+            model.put(CONDITION_FULFILLED, antall + 1);
         }
     }
 

--- a/src/main/java/no/nav/foreldrepenger/fpdokgen/tjenester/dokumentgenerator/handlebars/HandlebarsTjeneste.java
+++ b/src/main/java/no/nav/foreldrepenger/fpdokgen/tjenester/dokumentgenerator/handlebars/HandlebarsTjeneste.java
@@ -46,7 +46,6 @@ public class HandlebarsTjeneste {
         handlebars.registerHelper("size", new HandlebarsCustomHelpers.SizeHelper());
         handlebars.registerHelper("switch", new HandlebarsCustomHelpers.SwitchHelper());
         handlebars.registerHelper("case", new HandlebarsCustomHelpers.CaseHelper());
-        handlebars.registerHelper("table", new HandlebarsCustomHelpers.TableHelper());
         handlebars.registerHelper("add", new HandlebarsCustomHelpers.AdditionHelper());
         handlebars.registerHelper("norwegian-date", new HandlebarsCustomHelpers.NorwegianDateHelper());
         handlebars.registerHelper("norwegian-datetime", new HandlebarsCustomHelpers.NorwegianDateTimeHelper());

--- a/src/test/java/content/templates/EngangsstønadAvslagSwitchCaseTest.java
+++ b/src/test/java/content/templates/EngangsstønadAvslagSwitchCaseTest.java
@@ -1,0 +1,97 @@
+package content.templates;
+
+import static content.support.TemplateTestUtil.compileContent;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import content.support.BrevMal;
+import content.support.Språk;
+
+/**
+ * Dekker switch/case-grener i engangsstønad-avslag enkeltvis.
+ * <p>
+ * Denne malen bruker {{#switch avslagÅrsak}} der avslagÅrsak er en scalar streng (ikke array).
+ * Mønsteret skiller seg fra foreldrepenger-opphør, som itererer over en array og refererer
+ * {{../this}} inni case — det var kun sistnevnte kombinasjon som brøt ved handlebars 4.5.2.
+ * Testene her låser scalar-switch-oppførselen så en framtidig endring i helper-logikken fanges.
+ */
+class EngangsstønadAvslagSwitchCaseTest {
+
+    private static final BrevMal BREVMAL = BrevMal.ENGANGSSTØNAD_AVSLAG;
+
+    @Test
+    void case_søker_er_utvandret() {
+        var content = compileContent(BREVMAL, Språk.BOKMÅL, testData("SØKER_ER_UTVANDRET"));
+        assertThat(content).contains("Ifølge folkeregisteret har du flyttet fra Norge.");
+    }
+
+    @Test
+    void case_søker_er_ikke_medlem() {
+        var content = compileContent(BREVMAL, Språk.BOKMÅL, testData("SØKER_ER_IKKE_MEDLEM"));
+        assertThat(content).contains("Du er omfattet av trygdeordningen i et annet land.");
+    }
+
+    @Test
+    void case_søker_har_ikke_lovlig_opphold() {
+        var content = compileContent(BREVMAL, Språk.BOKMÅL, testData("SØKER_HAR_IKKE_LOVLIG_OPPHOLD"));
+        assertThat(content).contains("Du har ikke oppholdstillatelse i Norge.");
+    }
+
+    @Test
+    void case_søker_har_ikke_oppholdsrett() {
+        var content = compileContent(BREVMAL, Språk.BOKMÅL, testData("SØKER_HAR_IKKE_OPPHOLDSRETT"));
+        assertThat(content).contains("Det er derfor ikke dokumentert at du har rett til opphold etter EØS-avtalen.");
+    }
+
+    @Test
+    void case_med_nested_eq_ett_barn() {
+        var testData = testData("IKKE_ALENEOMSORG");
+        testData.put("antallBarn", 1);
+        var content = compileContent(BREVMAL, Språk.BOKMÅL, testData);
+        assertThat(content).contains("du ikke har aleneomsorgen for barnet ditt.");
+    }
+
+    @Test
+    void case_med_nested_eq_flere_barn() {
+        var testData = testData("IKKE_ALENEOMSORG");
+        testData.put("antallBarn", 2);
+        var content = compileContent(BREVMAL, Språk.BOKMÅL, testData);
+        assertThat(content).contains("du ikke har aleneomsorgen for barna dine.");
+    }
+
+    @Test
+    void case_med_nested_if_medlemskapfom_satt() {
+        var testData = testData("SØKER_INNFLYTTET_FOR_SENT");
+        testData.put("medlemskapFom", "1. mars 2026");
+        var content = compileContent(BREVMAL, Språk.BOKMÅL, testData);
+        assertThat(content).contains("Vi har opplysninger om at du flyttet til Norge 1. mars 2026.");
+    }
+
+    @Test
+    void ukjent_case_gir_ingen_avslagstekst() {
+        var content = compileContent(BREVMAL, Språk.BOKMÅL, testData("EN_KODE_SOM_IKKE_FINNES"));
+        assertThat(content).doesNotContain("Ifølge folkeregisteret har du flyttet fra Norge.");
+    }
+
+    private Map<String, Object> testData(String avslagÅrsak) {
+        var testData = new HashMap<String, Object>();
+        testData.put("førstegangsbehandling", true);
+        testData.put("antallBarn", 1);
+        testData.put("avslagÅrsak", avslagÅrsak);
+        testData.put("klagefristUker", 6);
+
+        var felles = new HashMap<String, Object>();
+        felles.put("søkerNavn", "DONALD DUCK");
+        felles.put("søkerPersonnummer", "12345 66789");
+        felles.put("brevDato", "4. mai 2021");
+        felles.put("erAutomatiskBehandlet", true);
+        felles.put("saksnummer", "123456789");
+        felles.put("erUtkast", false);
+        testData.put("felles", felles);
+        return testData;
+    }
+}

--- a/src/test/java/content/templates/ForeldrepengerOpphørTest.java
+++ b/src/test/java/content/templates/ForeldrepengerOpphørTest.java
@@ -143,6 +143,69 @@ class ForeldrepengerOpphørTest {
             "Du hadde ikke rett til foreldrepenger fordi du ikke var medlem i folketrygden på det tidspunktet barna dine ble født.\nVi har ikke opplysninger om at du jobbet eller hadde familie som forsørget deg i Norge. Det var derfor ikke dokumentert at du hadde rett til opphold etter EØS-avtalen.");
     }
 
+    @Test
+    void test_kode_søker_1020_medlem_annet_land() {
+        var testData = opprettTestData();
+        testData.remove("opphørDato");
+        opprettÅrsaker(testData, "1020");
+
+        var content = compileContent(BREVMAL, Språk.BOKMÅL, testData);
+        assertThat(content).contains("Du var omfattet av trygdeordningen i et annet land.");
+    }
+
+    @Test
+    void test_kode_søker_1021_flyttet_fra_norge() {
+        var testData = opprettTestData();
+        testData.remove("opphørDato");
+        opprettÅrsaker(testData, "1021");
+
+        var content = compileContent(BREVMAL, Språk.BOKMÅL, testData);
+        assertThat(content).contains("Ifølge folkeregisteret hadde du flyttet fra Norge.");
+    }
+
+    @Test
+    void test_kode_søker_1023_ingen_oppholdstillatelse() {
+        var testData = opprettTestData();
+        testData.remove("opphørDato");
+        opprettÅrsaker(testData, "1023");
+
+        var content = compileContent(BREVMAL, Språk.BOKMÅL, testData);
+        assertThat(content).contains("Du hadde ikke oppholdstillatelse i Norge.");
+    }
+
+    @Test
+    void test_kode_søker_1025_mer_i_utlandet() {
+        var testData = opprettTestData();
+        testData.remove("opphørDato");
+        opprettÅrsaker(testData, "1025");
+
+        var content = compileContent(BREVMAL, Språk.BOKMÅL, testData);
+        assertThat(content).contains("Du regnes ikke som medlem fordi du oppholdt deg mer i utlandet enn i Norge.");
+    }
+
+    @Test
+    void test_flere_årsaker_rendrer_alle_tekstene() {
+        var testData = opprettTestData();
+        testData.remove("opphørDato");
+        opprettÅrsaker(testData, "1020", "1021");
+
+        var content = compileContent(BREVMAL, Språk.BOKMÅL, testData);
+        assertThat(content)
+            .contains("Du var omfattet av trygdeordningen i et annet land.")
+            .contains("Ifølge folkeregisteret hadde du flyttet fra Norge.");
+    }
+
+    @Test
+    void test_ukjent_kode_gir_ingen_avslagstekst() {
+        var testData = opprettTestData();
+        opprettÅrsaker(testData, "9999");
+
+        var content = compileContent(BREVMAL, Språk.BOKMÅL, testData);
+        assertThat(content)
+            .doesNotContain("Du var omfattet av trygdeordningen i et annet land.")
+            .doesNotContain("Du hadde ikke rett til foreldrepenger fordi du ikke var registrert");
+    }
+
     private void opprettÅrsaker(final Map<String, Object> testData, String... årsaker) {
         var årsakArray = JacksonUtil.JSON_MAPPER.createArrayNode();
         for (var årsak : årsaker) {

--- a/src/test/java/no/nav/foreldrepenger/fpdokgen/tjenester/dokumentgenerator/handlebars/HandlebarsCustomHelpersTest.java
+++ b/src/test/java/no/nav/foreldrepenger/fpdokgen/tjenester/dokumentgenerator/handlebars/HandlebarsCustomHelpersTest.java
@@ -401,37 +401,6 @@ class HandlebarsCustomHelpersTest {
     }
 
     @Nested
-    class TableHelperTest {
-
-        @Test
-        void skalLageTabellMedToKolonner() throws IOException {
-            var template = handlebars.compileInline("{{#table columns=2}}<td>A</td><td>B</td><td>C</td><td>D</td>{{/table}}");
-            var result = template.apply(null);
-            assertThat(result).contains("<table")
-                .contains("<tr>")
-                .contains("</tr>")
-                .contains("<td>A</td>")
-                .contains("<td>B</td>")
-                .contains("<td>C</td>")
-                .contains("<td>D</td>");
-        }
-
-        @Test
-        void skalFylleUtTommeCellerVedUjevntAntall() throws IOException {
-            var template = handlebars.compileInline("{{#table columns=2}}<td>A</td><td>B</td><td>C</td>{{/table}}");
-            var result = template.apply(null);
-            assertThat(result).contains("<td></td>");
-        }
-
-        @Test
-        void skalLeggesTilClassAttributt() throws IOException {
-            var template = handlebars.compileInline("{{#table columns=2 class=\"min-tabell\"}}<td>A</td>{{/table}}");
-            var result = template.apply(null);
-            assertThat(result).contains("class=min-tabell");
-        }
-    }
-
-    @Nested
     class InArrayHelperTest {
 
         @Test
@@ -474,6 +443,34 @@ class HandlebarsCustomHelpersTest {
                 """);
             var result = template.apply(java.util.Map.of("status", "INAKTIV"));
             assertThat(result.trim()).isEqualTo("Inaktiv bruker");
+        }
+
+        @Test
+        void skalMatcheCaseMotArrayAvKonstanter() throws IOException {
+            var template = handlebars.compileInline("""
+                {{#switch status}}
+                    {{#case (array "AKTIV" "PENDING")}}Treff{{/case}}
+                    {{#case "INAKTIV"}}Bom{{/case}}
+                {{/switch}}
+                """);
+            var result = template.apply(java.util.Map.of("status", "PENDING"));
+            assertThat(result.trim()).isEqualTo("Treff");
+        }
+
+
+        @Test
+        void skalStøtteNestedeHjelpereInniCase() throws IOException {
+            var template = handlebars.compileInline("""
+                {{#switch avslagsårsak}}
+                    {{#case (array "1027" "1029")}}
+                        {{#in-array (array "FARA" "MMOR") relasjonsRolleType}}
+                            Du er {{#eq relasjonsRolleType "MMOR"}}medmor{{/eq}}{{#eq relasjonsRolleType "FARA"}}far{{/eq}}
+                        {{/in-array}}
+                    {{/case}}
+                {{/switch}}
+                """);
+            var result = template.apply(java.util.Map.of("avslagsårsak", "1027", "relasjonsRolleType", "MMOR"));
+            assertThat(result).contains("Du er medmor");
         }
     }
 


### PR DESCRIPTION
Problemet var switch case som inneholdt andre statements inne i case blokken. Har dette i opphørsbrev fp

Endrer switch/case-helperne til å bruke vanlig child context i stedet for block-param context, siden handlebars 4.5.2 endret helper-resolusjon i block-param-scope og enkelte brev mistet case-innhold.

Fjerner ubrukt table-helper og legger til regresjonstester for switch/case-mønstre i brevmaler.