### PR TITLE
TFP-7042 felles jetty server builder

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
         <sonar.projectName>fp-dokgen</sonar.projectName>
         <sonar.projectKey>navikt_fp-dokgen</sonar.projectKey>
 
-        <felles.version>7.8.3</felles.version>
+        <felles.version>7.8.5</felles.version>
 
         <openhtmltopdf.version>1.1.37</openhtmltopdf.version>
         <commonmark.version>0.28.0</commonmark.version>

--- a/src/main/java/no/nav/foreldrepenger/fpdokgen/server/JettyServer.java
+++ b/src/main/java/no/nav/foreldrepenger/fpdokgen/server/JettyServer.java
@@ -1,16 +1,5 @@
 package no.nav.foreldrepenger.fpdokgen.server;
 
-import org.eclipse.jetty.ee11.cdi.CdiDecoratingListener;
-import org.eclipse.jetty.ee11.cdi.CdiServletContainerInitializer;
-import org.eclipse.jetty.ee11.servlet.DefaultServlet;
-import org.eclipse.jetty.ee11.servlet.ServletContextHandler;
-import org.eclipse.jetty.ee11.servlet.ServletHolder;
-import org.eclipse.jetty.ee11.servlet.security.ConstraintMapping;
-import org.eclipse.jetty.ee11.servlet.security.ConstraintSecurityHandler;
-import org.eclipse.jetty.security.Constraint;
-import org.eclipse.jetty.server.Server;
-import org.eclipse.jetty.server.ServerConnector;
-import org.glassfish.jersey.servlet.ServletContainer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.bridge.SLF4JBridgeHandler;
@@ -18,13 +7,11 @@ import org.slf4j.bridge.SLF4JBridgeHandler;
 import no.nav.foreldrepenger.fpdokgen.server.app.api.ApiConfig;
 import no.nav.foreldrepenger.fpdokgen.server.app.internal.InternalApiConfig;
 import no.nav.foreldrepenger.konfig.Environment;
-
-import java.util.concurrent.TimeUnit;
+import no.nav.vedtak.server.jetty.JettyServerBuilder;
 
 public class JettyServer {
     private static final Logger LOG = LoggerFactory.getLogger(JettyServer.class);
     private static final Environment ENV = Environment.current();
-    protected static final String APPLICATION = "jakarta.ws.rs.Application";
 
     private static final String CONTEXT_PATH = ENV.getProperty("context.path", "/fpdokgen");
 
@@ -57,70 +44,15 @@ public class JettyServer {
     }
 
     private void start() throws Exception {
-            LOG.info("Starter server");
-            var server = new Server();
-            var connector = new ServerConnector(server);
-            connector.setPort(getServerPort());
-            connector.setIdleTimeout(TimeUnit.MINUTES.toMillis(2));
-            server.addConnector(connector);
-
-            var context = new ServletContextHandler(CONTEXT_PATH, ServletContextHandler.NO_SESSIONS);
-
-            // Sikkerhet
-            context.setSecurityHandler(simpleConstraints());
-
-            // Servlets
-            registerDefaultServlet(context);
-            registerServlet(context, 0, InternalApiConfig.API_URI, InternalApiConfig.class);
-            registerServlet(context, 1, ApiConfig.API_URI, ApiConfig.class);
-
-            // Enable Weld + CDI
-            context.setInitParameter(CdiServletContainerInitializer.CDI_INTEGRATION_ATTRIBUTE, CdiDecoratingListener.MODE);
-            context.addServletContainerInitializer(new CdiServletContainerInitializer());
-            context.addServletContainerInitializer(new org.jboss.weld.environment.servlet.EnhancedListener());
-
-            server.setHandler(context);
-            server.setStopAtShutdown(true);
-            server.setStopTimeout(10000);
-            server.start();
-
-            LOG.info("Server startet på port: {}", getServerPort());
-            server.join();
+        LOG.info("Starter server");
+        var server = JettyServerBuilder.builder()
+            .port(serverPort)
+            .contextPath(CONTEXT_PATH)
+            .registerRestApp(InternalApiConfig.API_URI, InternalApiConfig.class)
+            .registerRestApp(ApiConfig.API_URI, ApiConfig.class)
+            .build();
+        server.start();
+        LOG.info("Server startet på port: {}", serverPort);
+        server.join();
     }
-
-    private static void registerDefaultServlet(ServletContextHandler context) {
-        var defaultServlet = new ServletHolder(new DefaultServlet());
-        context.addServlet(defaultServlet, "/*");
-    }
-
-    private static void registerServlet(ServletContextHandler context, int prioritet, String path, Class<?> appClass) {
-        var servlet = new ServletHolder(new ServletContainer());
-        servlet.setInitOrder(prioritet);
-        servlet.setInitParameter(APPLICATION, appClass.getName());
-        servlet.setName(appClass.getName());
-        context.addServlet(servlet, path + "/*");
-    }
-
-    private static ConstraintSecurityHandler simpleConstraints() {
-        var handler = new ConstraintSecurityHandler();
-        // Slipp gjennom kall fra plattform til JaxRs. Foreløpig kun behov for GET
-        handler.addConstraintMapping(pathConstraint(Constraint.ALLOWED, InternalApiConfig.API_URI + "/*"));
-        // Slipp gjennom til autentisering i JaxRs / auth-filter
-        handler.addConstraintMapping(pathConstraint(Constraint.ALLOWED, ApiConfig.API_URI + "/*"));
-        // Alt annet av paths og metoder forbudt - 403
-        handler.addConstraintMapping(pathConstraint(Constraint.FORBIDDEN, "/*"));
-        return handler;
-    }
-
-    private static ConstraintMapping pathConstraint(Constraint constraint, String path) {
-        var mapping = new ConstraintMapping();
-        mapping.setConstraint(constraint);
-        mapping.setPathSpec(path);
-        return mapping;
-    }
-
-    private Integer getServerPort() {
-        return this.serverPort;
-    }
-
 }


### PR DESCRIPTION
Adopterer felles JettyServerBuilder fra fp-felles (felles/server jetty-pakke) og oppgraderer felles til 7.8.5.

- Erstatter manuell Jetty/Connector/Context/sikkerhets-oppsett med JettyServerBuilder
- MetricsUtil.scrape() -> MetricsUtil.init() tidlig i boot (før logging/datasource), der relevant
- Legger til DataSourceShutdownListener der datasource/Flyway brukes

TFP-7042