### PR TITLE
TFP-7102 Kjønnsnøytral tekst i annulleringsbrev

### DIFF
--- a/src/main/resources/content/templates/foreldrepenger-annullert/template_en.hbs
+++ b/src/main/resources/content/templates/foreldrepenger-annullert/template_en.hbs
@@ -21,7 +21,7 @@ You receive care benefit instead of parental benefit during the period you had b
 
 {{/case}}
 {{~#case "ANNEN_PART_OVERTAR_UTTAKET"}}
-The mother has applied to take over your previously granted parental benefit period. Therefore, your parental benefit has ended, but you do not lose any days.
+The other parent has applied to take over your previously granted parental benefit period. Therefore, your parental benefit has ended, but you do not lose any days.
 
 {{/case}}
 {{~/switch}}

--- a/src/main/resources/content/templates/foreldrepenger-annullert/template_nb.hbs
+++ b/src/main/resources/content/templates/foreldrepenger-annullert/template_nb.hbs
@@ -21,7 +21,7 @@ Du mottar pleiepenger istedenfor foreldrepenger i perioden du hadde fått innvil
 
 {{/case}}
 {{~#case "ANNEN_PART_OVERTAR_UTTAKET"}}
-Mor har søkt om overtakelse av din tidligere innvilgede periode med foreldrepenger. Derfor er foreldrepengene dine opphørt, men du mister ikke dager.
+Den andre forelderen har søkt om overtakelse av din tidligere innvilgede periode med foreldrepenger. Derfor er foreldrepengene dine opphørt, men du mister ikke dager.
 
 {{/case}}
 {{~/switch}}

--- a/src/main/resources/content/templates/foreldrepenger-annullert/template_nn.hbs
+++ b/src/main/resources/content/templates/foreldrepenger-annullert/template_nn.hbs
@@ -21,7 +21,7 @@ Du får pleiepengar i staden for foreldrepengar i perioden du hadde fått innvil
 
 {{/case}}
 {{~#case "ANNEN_PART_OVERTAR_UTTAKET"}}
-Mor har søkt om overtaking av din tidlegare innvilga perioden med foreldrapengar. Difor er foreldrepengane dine avslutta, men du mistar ikkje dagar.
+Den andre forelderen har søkt om overtaking av den tidlegare innvilga perioden din med foreldrepengar. Difor er foreldrepengane dine avslutta, men du mistar ikkje dagar.
 
 {{/case}}
 {{~/switch}}

--- a/src/test/resources/testdata/foreldrepenger-annullert/expected/foreldrepenger-annullert_pga_annen_part_overtar_uttaket_en.txt
+++ b/src/test/resources/testdata/foreldrepenger-annullert/expected/foreldrepenger-annullert_pga_annen_part_overtar_uttaket_en.txt
@@ -21,7 +21,7 @@
 <div id="redigerbart-innhold" data-editable="data-editable">
 #  Nav has changed your parental benefit
 The previously granted period of parental benefit has been annulled.
-The mother has applied to take over your previously granted parental benefit period. Therefore, your parental benefit has ended, but you do not lose any days.
+The other parent has applied to take over your previously granted parental benefit period. Therefore, your parental benefit has ended, but you do not lose any days.
 You must apply for a new parental benefit period at [nav.no/foreldrepenger](https://nav.no/foreldrepenger). The parental benefit must be withdrawn no later than the day before the new parental benefit period for a new child begins, or no later than the day before the child reaches the age of three.
 When there are 4 weeks or less left until you are to withdraw your parental benefit, your employer must submit a new income report.
 The decision has been made pursuant to section 14-6, 14-7, 14-9, 14-10, 14-11 and 14-12 of the National Insurance Act.

--- a/src/test/resources/testdata/foreldrepenger-annullert/expected/foreldrepenger-annullert_pga_annen_part_overtar_uttaket_nb.txt
+++ b/src/test/resources/testdata/foreldrepenger-annullert/expected/foreldrepenger-annullert_pga_annen_part_overtar_uttaket_nb.txt
@@ -21,7 +21,7 @@
 <div id="redigerbart-innhold" data-editable="data-editable">
 #  Nav har endret foreldrepengene dine
 Din tidligere innvilgede periode med foreldrepenger ble annullert.
-Mor har søkt om overtakelse av din tidligere innvilgede periode med foreldrepenger. Derfor er foreldrepengene dine opphørt, men du mister ikke dager.
+Den andre forelderen har søkt om overtakelse av din tidligere innvilgede periode med foreldrepenger. Derfor er foreldrepengene dine opphørt, men du mister ikke dager.
 Du må søke om ny foreldrepengeperiode på [nav.no/foreldrepenger](https://nav.no/foreldrepenger). Foreldrepengene må være tatt ut senest dagen før ny foreldrepengeperiode for nytt barn starter, eller senest dagen før barnet fyller tre år.
 Når det er 4 uker eller mindre igjen til du skal ta ut foreldrepenger, må arbeidsgiveren din sende inn ny inntektsmelding.
 Vedtaket er gjort etter folketrygdloven §§ 14-6, 14-7, 14-9, 14-10, 14-11 og 14-12.

--- a/src/test/resources/testdata/foreldrepenger-annullert/expected/foreldrepenger-annullert_pga_annen_part_overtar_uttaket_nn.txt
+++ b/src/test/resources/testdata/foreldrepenger-annullert/expected/foreldrepenger-annullert_pga_annen_part_overtar_uttaket_nn.txt
@@ -21,7 +21,7 @@
 <div id="redigerbart-innhold" data-editable="data-editable">
 #  Nav har endra foreldrepengane dine
 Den tidlegare innvilga perioden din med foreldrepengar vart annullert.
-Mor har søkt om overtaking av din tidlegare innvilga perioden med foreldrapengar. Difor er foreldrepengane dine avslutta, men du mistar ikkje dagar.
+Den andre forelderen har søkt om overtaking av den tidlegare innvilga perioden din med foreldrepengar. Difor er foreldrepengane dine avslutta, men du mistar ikkje dagar.
 Du må søkje om ny foreldrepengeperiode på [nav.no/foreldrepenger](https://nav.no/foreldrepenger). Foreldrepengane må vere tatt ut seinast dagen før ny foreldrepengeperiode for nytt barn startar, eller seinast dagen før barnet fyller tre år.
 Når det er 4 veker eller mindre igjen til du skal ta ut foreldrepengar, må arbeidsgivaren din sende inn ny inntektsmelding.
 Vedtaket er gjort etter folketrygdlova §§ 14-6, 14-7, 14-9, 14-10, 14-11 og 14-12.


### PR DESCRIPTION
## Endring
- erstatter «Mor» med kjønnsnøytral omtale av den andre forelderen
- oppdaterer bokmål, nynorsk og engelsk
- oppdaterer forventet brevtekst for alle språk

## Test
- `mvn -Dtest=ForeldrepengerAnnullertTest test`

[Jira TFP-7102](https://jira.adeo.no/browse/TFP-7102)